### PR TITLE
feat: hexagonal architecture, sync protocol, CI, CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "feat/**", "fix/**", "refactor/**", "chore/**"]
+  pull_request:
+    branches: ["main"]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  ci:
+    name: CI
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Format
+        run: cargo fmt --check
+
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Tests
+        run: cargo test --workspace

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -31,7 +31,71 @@ ZamSync does **not** resolve semantic conflicts (e.g., two people editing the sa
 - The application (StateStore) must be written to be a **deterministic reducer**.
 - If two updates to the same field are concurrent, the reducer will receive them in a deterministic order (e.g., $E_{A}$ then $E_{B}$ on every node).
 
-## 5. ZamSync Consistency Contract
+## 4. Hexagonal Architecture (Ports and Adapters)
+
+ZamSync applies hexagonal architecture to decouple the sync core from storage and transport backends.
+
+### Crate Layout
+
+```
+zamsync-core        -- domain types + port traits (no I/O)
+zamsync-storage     -- WAL adapter, file peer store, engine
+zamsync-network     -- TCP transport adapter, binary wire protocol
+zamsync-testing     -- in-memory adapters, mock transport, helpers
+zamsync (binary)    -- CLI entry point
+```
+
+### Port Traits (zamsync-core::ports)
+
+| Trait        | Responsibility |
+|--------------|----------------|
+| `EventStore` | Append and scan durable events |
+| `PeerStore`  | Persist and load `ReplicationState` |
+| `StateStore` | Domain projection: apply events to application state |
+| `Transport`  | Send and receive `SyncMessage` to/from peers |
+
+All I/O goes through these traits. The engine (`ZamEngine<E, P, S>`) is generic over them and contains zero filesystem or network code.
+
+### Adapter Implementations
+
+| Adapter             | Implements   | Crate              |
+|---------------------|--------------|--------------------|
+| `WalEventStore`     | `EventStore` | zamsync-storage    |
+| `FilePeerStore`     | `PeerStore`  | zamsync-storage    |
+| `TcpTransport`      | `Transport`  | zamsync-network    |
+| `InMemoryEventStore`| `EventStore` | zamsync-testing    |
+| `InMemoryPeerStore` | `PeerStore`  | zamsync-testing    |
+| `MockTransport`     | `Transport`  | zamsync-testing    |
+
+`StateStore` is always implemented by the application. ZamSync ships no concrete implementation because the projection is domain-specific.
+
+## 5. Sync Protocol
+
+Nodes exchange `SyncMessage` frames during each sync session.
+
+### Message Flow
+
+```
+Initiator (A)                 Responder (B)
+    |                               |
+    |-- Handshake(vv_A) ----------->|
+    |                               |
+    |<-- Handshake(vv_B) -----------|
+    |<-- EventBatch(events B has)---|  (zero or more batches)
+    |<-- SyncComplete --------------|
+    |                               |
+    |-- EventBatch(events A has) -->|  (zero or more batches)
+    |-- SyncComplete -------------->|
+```
+
+### Key Properties
+
+- **Handshake** carries the sender's Version Vector. The responder computes gaps and pushes missing events immediately.
+- **SyncComplete** marks the end of one direction's transmission. Both sides send it before considering the session done.
+- **Idempotency**: `apply_replicated` checks the local VV before writing. Duplicate deliveries are silently ignored.
+- **Gap semantics**: `find_gaps` returns `(node_id, start_seq)` where `start_seq` is the first event the requester needs (inclusive). For nodes never seen, `start_seq = SequenceNumber::ZERO`.
+
+## 6. ZamSync Consistency Contract
 
 This contract defines the strict relationship between the ZamSync Engine and the Application Layer (`StateStore`).
 
@@ -47,7 +111,7 @@ This contract defines the strict relationship between the ZamSync Engine and the
     - For simple fields, the application may use the **HLC Order** as a "Last-Writer-Wins" mechanism.
     - For complex data (e.g., medical logs), the application should use **Multi-Value** or **CRDT** patterns to avoid data loss during concurrent updates.
 
-## 6. Definitions of "Correct State"
+## 7. Definitions of "Correct State"
 
 A node's state is **Correct** if it is the result of replaying the deterministic sequence of all events in its local knowledge.
 A system is **Converged** when all nodes have the same Version Vector and have replayed their logs.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,6 +792,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "zamsync"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "zamsync-core",
+ "zamsync-storage",
+]
+
+[[package]]
 name = "zamsync-core"
 version = "0.1.0"
 dependencies = [
@@ -823,6 +832,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "zamsync-core",
+ "zamsync-testing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,6 +830,7 @@ name = "zamsync-testing"
 version = "0.1.0"
 dependencies = [
  "zamsync-core",
+ "zamsync-storage",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,20 @@
 [workspace]
 resolver = "2"
 members = [
+    ".",
     "crates/zamsync-core",
     "crates/zamsync-storage",
     "crates/zamsync-network",
     "crates/zamsync-testing",
 ]
+
+[package]
+name = "zamsync"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description.workspace = true
 
 [workspace.package]
 version = "0.1.0"
@@ -13,6 +22,11 @@ edition = "2021"
 authors = ["ZamSync Contributors"]
 license = "MIT"
 description = "Resilient Offline-First Synchronization Engine"
+
+[dependencies]
+zamsync-storage = { path = "crates/zamsync-storage" }
+zamsync-core = { path = "crates/zamsync-core" }
+log.workspace = true
 
 [workspace.dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ZamSync — Resilient Offline-First Synchronization Engine
+# ZamSync -- Resilient Offline-First Synchronization Engine
 
 ZamSync is a systems-level synchronization engine designed for environments where network connectivity is unreliable, intermittent, or extremely low-bandwidth.
 
@@ -12,83 +12,113 @@ Reliable digital infrastructure is still a major challenge in remote regions wor
 
 In countries with complex geography such as Bhutan, large parts of the territory are composed of high-altitude terrain, making connectivity inconsistent across villages, clinics, and administrative centers.
 
-Public digital transformation initiatives such as national e-health systems (e.g., electronic patient record systems like ePIS) face recurring challenges:
+Public digital transformation initiatives such as national e-health systems face recurring challenges:
 
 - unstable or intermittent connectivity
 - high latency links (2G / satellite / constrained mobile networks)
 - frequent disconnections during data synchronization
 - fallback to manual or paper-based workflows during outages
 
-This leads to a fundamental issue:
-
-> Most modern synchronization systems assume stable connectivity, which does not hold in these environments.
-
----
-
-## Problem Statement
-
-Traditional approaches (REST APIs, JSON-based synchronization, cloud-first architectures) introduce:
-
-- high protocol overhead
-- inefficient bandwidth usage
-- poor resilience to disconnections
-- inability to resume transfers at fine granularity
-- strong dependency on persistent connectivity
-
-ZamSync is designed to operate under the opposite assumption:
-
-> The network is unreliable by default.
-
 ---
 
 ## Design Goals
 
-ZamSync aims to provide a synchronization layer that is:
+ZamSync is:
 
 - offline-first by design
 - resilient to frequent and unpredictable disconnections
 - highly bandwidth-efficient
 - deterministic and replay-safe
-- capable of exact resumability after failure
-- suitable for low-resource devices in constrained environments
+- domain-agnostic (no healthcare-specific logic inside the engine)
 
 ---
 
-## System Architecture
+## Architecture
 
-### 1. Storage Layer
+ZamSync uses **hexagonal architecture** (ports and adapters). The sync core is a set of pure Rust traits with no I/O. Storage and transport are pluggable adapters.
 
-- Local persistent database (SQLite or embedded key-value store)
-- Write-Ahead Log (WAL) as the source of truth
-- Append-only event model
-- State reconstruction from deterministic event replay
+```
+zamsync-core        -- Event, HLC, VersionVector, SyncMessage, port traits
+zamsync-storage     -- WAL event store, file peer store, ZamEngine
+zamsync-network     -- TCP transport, binary wire protocol
+zamsync-testing     -- In-memory adapters, MockTransport, run_direct_sync
+zamsync (binary)    -- CLI: info, submit
+```
+
+### Port Traits
+
+```rust
+// Implement StateStore to project events into your domain model
+pub trait StateStore {
+    fn apply_event(&mut self, seq: SequenceNumber, event: &Event) -> ZamResult<()>;
+    fn last_applied_seq(&self) -> Option<SequenceNumber>;
+}
+```
+
+The engine `ZamEngine<E: EventStore, P: PeerStore, S: StateStore>` is generic over all I/O. The WAL-backed stack is accessible via `ZamEngine::open_wal(data_dir, node_id, state)`.
+
+### Sync Protocol
+
+Peers exchange `SyncMessage` frames. A session:
+
+1. Both sides send a `Handshake` carrying their Version Vector.
+2. Each side computes gaps and pushes missing `EventBatch` messages.
+3. Each side sends `SyncComplete` when done.
+
+Events are idempotent: duplicate deliveries are dropped via VV check.
 
 ---
 
-### 2. Synchronization Layer
+## Getting Started
 
-- Event-based replication model
-- Sequence-based or version-based diff detection
-- Incremental synchronization using missing event ranges
-- Idempotent application of events across nodes
+### Build
+
+```bash
+cargo build --release
+```
+
+### CLI
+
+```bash
+# Show node status (creates data dir on first run)
+./target/release/zamsync info /var/lib/zamsync/node1
+
+# Submit an event
+./target/release/zamsync submit /var/lib/zamsync/node1 "hello world"
+```
+
+Node identity is stored in `<data-dir>/.node_id` and generated automatically on first start.
+
+### Using the Engine in Your Application
+
+```rust
+use zamsync_storage::ZamEngine;
+use zamsync_core::{NodeId, ports::StateStore, Event, SequenceNumber, ZamResult};
+
+struct MyState { /* ... */ }
+
+impl StateStore for MyState {
+    fn apply_event(&mut self, _seq: SequenceNumber, event: &Event) -> ZamResult<()> {
+        // project the event into your domain model
+        Ok(())
+    }
+    fn last_applied_seq(&self) -> Option<SequenceNumber> { None }
+}
+
+let mut engine = ZamEngine::open_wal("./data", NodeId(1), MyState { /* ... */ })?;
+engine.submit(1, b"my payload".to_vec())?;
+engine.sync()?; // flush WAL and persist replication state
+```
 
 ---
 
-### 3. Transport Layer
+## Testing
 
-- Lightweight binary protocol optimized for minimal overhead
-- Chunk-based transfer system for large payloads
-- Explicit acknowledgment mechanism (range or bitmap-based)
-- Full resumability after interruption without retransfer
+```bash
+cargo test --workspace
+```
 
----
-
-### 4. Serialization Layer
-
-- Compact binary encoding (varint-based structures)
-- Optional compression layer (e.g. zstd)
-- Schema-driven event representation
-- Optional dictionary encoding for frequent domain terms
+The `zamsync-testing` crate provides in-memory adapters and `run_direct_sync` for convergence tests without any I/O.
 
 ---
 
@@ -97,69 +127,12 @@ ZamSync aims to provide a synchronization layer that is:
 The system is explicitly designed to tolerate:
 
 - frequent network disconnections
-- high packet loss rates
+- high packet loss
 - long offline periods
 - partial transfers
-- corrupted or incomplete transmissions
+- corrupted or incomplete WAL entries (detected via CRC32)
 
-All operations are retry-safe and idempotent by design.
-
----
-
-## Data Integrity Model
-
-ZamSync enforces:
-
-- per-chunk checksum validation
-- event-level integrity verification
-- replay-safe event application
-- explicit detection of corruption or incomplete state
-
-No silent data loss is permitted under any failure scenario.
-
----
-
-## Testing Strategy
-
-Every component must be validated under realistic conditions.
-
-### Unit Testing
-- serialization correctness
-- WAL consistency
-- event validation logic
-- edge-case input handling
-
-### Integration Testing
-- storage and synchronization interaction
-- transport and recovery behavior
-
-### Failure Simulation
-- high latency networks
-- packet loss up to extreme levels
-- sudden disconnections
-- corrupted data streams
-
-### Determinism Testing
-- identical state reconstruction across repeated runs
-- consistent sync outcomes across nodes
-
----
-
-## Benchmarking Requirements
-
-All implementations must be measured against baseline approaches such as:
-
-- REST/JSON synchronization
-- naive full-state replication
-- unoptimized file transfer systems
-
-Key metrics:
-
-- bandwidth usage
-- synchronization latency
-- recovery time after failure
-- memory footprint under constrained hardware
-- success rate under simulated network degradation
+All sync operations are retry-safe and idempotent.
 
 ---
 
@@ -167,21 +140,13 @@ Key metrics:
 
 ZamSync explicitly avoids:
 
-- blockchain-based consensus systems
+- blockchain-based consensus
 - cloud-first architectural dependency
-- heavy distributed coordination frameworks
-- unnecessary microservices complexity
+- semantic conflict resolution (this belongs in the StateStore)
 - assumptions of stable connectivity
 
 ---
 
 ## Long-Term Vision
 
-ZamSync is intended as a foundation for:
-
-- offline-first distributed systems
-- resilient synchronization in infrastructure-limited environments
-- low-bandwidth critical data replication systems
-- minimal alternatives to cloud-dependent synchronization tools
-
-The objective is to provide a predictable, deterministic, and robust synchronization engine that operates reliably where conventional systems fail.
+ZamSync is intended as a foundation for offline-first distributed systems in infrastructure-limited environments. The objective is to provide a predictable, deterministic, and robust synchronization engine that operates reliably where conventional systems fail.

--- a/crates/zamsync-core/src/event.rs
+++ b/crates/zamsync-core/src/event.rs
@@ -1,10 +1,23 @@
-use std::fmt;
 use rkyv::{Archive, Deserialize, Serialize};
+use std::fmt;
 
 pub const WAL_MAGIC: [u8; 4] = [0x5A, 0x41, 0x4D, 0x21];
 pub const WAL_VERSION: u8 = 1;
 
-#[derive(Archive, Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(
+    Archive,
+    Deserialize,
+    Serialize,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Default,
+)]
 #[archive(check_bytes)]
 pub struct Hlc {
     pub physical: u64,
@@ -41,12 +54,38 @@ impl Hlc {
     }
 }
 
-#[derive(Archive, Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(
+    Archive,
+    Deserialize,
+    Serialize,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Default,
+)]
 #[archive(check_bytes)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NodeId(pub u32);
 
-#[derive(Archive, Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(
+    Archive,
+    Deserialize,
+    Serialize,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Default,
+)]
 #[archive(check_bytes)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SequenceNumber(pub u64);

--- a/crates/zamsync-core/src/sync.rs
+++ b/crates/zamsync-core/src/sync.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
-use rkyv::{Archive, Deserialize, Serialize};
 use crate::{Event, NodeId, SequenceNumber};
+use rkyv::{Archive, Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Archive, Deserialize, Serialize, Debug, Clone, Default, PartialEq, Eq)]
 #[archive(check_bytes)]
@@ -14,14 +14,20 @@ impl VersionVector {
     }
 
     pub fn update(&mut self, node_id: NodeId, seq: SequenceNumber) {
-        let entry = self.entries.entry(node_id.0).or_insert(SequenceNumber::ZERO);
+        let entry = self
+            .entries
+            .entry(node_id.0)
+            .or_insert(SequenceNumber::ZERO);
         if seq > *entry {
             *entry = seq;
         }
     }
 
     pub fn get(&self, node_id: NodeId) -> SequenceNumber {
-        self.entries.get(&node_id.0).cloned().unwrap_or(SequenceNumber::ZERO)
+        self.entries
+            .get(&node_id.0)
+            .cloned()
+            .unwrap_or(SequenceNumber::ZERO)
     }
 
     pub fn find_gaps(&self, other: &VersionVector) -> Vec<(NodeId, SequenceNumber)> {

--- a/crates/zamsync-core/src/sync.rs
+++ b/crates/zamsync-core/src/sync.rs
@@ -30,13 +30,21 @@ impl VersionVector {
             .unwrap_or(SequenceNumber::ZERO)
     }
 
+    /// Returns the first sequence number this VV needs from `other`, for each node where
+    /// `other` is ahead. The returned `SequenceNumber` is the inclusive start of the gap
+    /// (i.e. `events_since(node, start)` should return events with `seq >= start`).
     pub fn find_gaps(&self, other: &VersionVector) -> Vec<(NodeId, SequenceNumber)> {
         let mut gaps = Vec::new();
         for (node_id_raw, other_seq) in &other.entries {
             let node_id = NodeId(*node_id_raw);
-            let local_seq = self.get(node_id);
-            if *other_seq > local_seq {
-                gaps.push((node_id, local_seq));
+            match self.entries.get(node_id_raw) {
+                Some(&local_last) if *other_seq > local_last => {
+                    gaps.push((node_id, local_last.next()));
+                }
+                None => {
+                    gaps.push((node_id, SequenceNumber::ZERO));
+                }
+                _ => {}
             }
         }
         gaps
@@ -74,4 +82,5 @@ pub enum SyncMessage {
         origin_node: NodeId,
         events: Vec<Event>,
     },
+    SyncComplete,
 }

--- a/crates/zamsync-network/src/protocol/codec.rs
+++ b/crates/zamsync-network/src/protocol/codec.rs
@@ -1,17 +1,16 @@
+use super::frame;
 use std::io::{Read, Write};
 use zamsync_core::{SyncMessage, ZamError, ZamResult};
-use super::frame;
 
 pub fn encode(msg: &SyncMessage, writer: &mut impl Write) -> ZamResult<()> {
-    let bytes = rkyv::to_bytes::<_, 1024>(msg)
-        .map_err(|e| ZamError::Serialization(e.to_string()))?;
+    let bytes =
+        rkyv::to_bytes::<_, 1024>(msg).map_err(|e| ZamError::Serialization(e.to_string()))?;
     frame::write_frame(writer, &bytes)
 }
 
 pub fn decode(reader: &mut impl Read) -> ZamResult<SyncMessage> {
     let bytes = frame::read_frame(reader)?;
-    rkyv::from_bytes::<SyncMessage>(&bytes)
-        .map_err(|e| ZamError::Serialization(format!("{}", e)))
+    rkyv::from_bytes::<SyncMessage>(&bytes).map_err(|e| ZamError::Serialization(format!("{}", e)))
 }
 
 #[cfg(test)]
@@ -55,7 +54,11 @@ mod tests {
         let decoded = decode(&mut cursor).unwrap();
 
         match decoded {
-            SyncMessage::PullRequest { origin_node, start_seq, limit } => {
+            SyncMessage::PullRequest {
+                origin_node,
+                start_seq,
+                limit,
+            } => {
                 assert_eq!(origin_node.0, 1);
                 assert_eq!(start_seq.0, 100);
                 assert_eq!(limit, 50);
@@ -86,7 +89,10 @@ mod tests {
         let decoded = decode(&mut cursor).unwrap();
 
         match decoded {
-            SyncMessage::EventBatch { origin_node, events } => {
+            SyncMessage::EventBatch {
+                origin_node,
+                events,
+            } => {
                 assert_eq!(origin_node.0, 3);
                 assert_eq!(events.len(), 1);
                 assert_eq!(events[0].payload, b"payload");

--- a/crates/zamsync-network/src/protocol/frame.rs
+++ b/crates/zamsync-network/src/protocol/frame.rs
@@ -1,5 +1,5 @@
-use std::io::{Read, Write};
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use std::io::{Read, Write};
 use zamsync_core::{ZamError, ZamResult};
 
 pub const MAX_FRAME_SIZE: u32 = 64 * 1024 * 1024;

--- a/crates/zamsync-network/src/transport/tcp.rs
+++ b/crates/zamsync-network/src/transport/tcp.rs
@@ -1,10 +1,10 @@
+use crate::protocol;
 use std::collections::HashMap;
 use std::io::BufWriter;
 use std::net::{TcpListener, TcpStream};
 use std::time::Duration;
-use zamsync_core::{NodeId, SyncMessage, ZamError, ZamResult};
 use zamsync_core::ports::Transport;
-use crate::protocol;
+use zamsync_core::{NodeId, SyncMessage, ZamError, ZamResult};
 
 pub struct TcpTransport {
     listener: TcpListener,
@@ -37,9 +37,10 @@ impl TcpTransport {
 
 impl Transport for TcpTransport {
     fn send(&mut self, peer_id: NodeId, message: &SyncMessage) -> ZamResult<()> {
-        let stream = self.peers.get_mut(&peer_id.0).ok_or_else(|| {
-            ZamError::Protocol(format!("no connection to peer {}", peer_id.0))
-        })?;
+        let stream = self
+            .peers
+            .get_mut(&peer_id.0)
+            .ok_or_else(|| ZamError::Protocol(format!("no connection to peer {}", peer_id.0)))?;
         let mut writer = BufWriter::new(stream as &TcpStream);
         protocol::encode(message, &mut writer)
     }

--- a/crates/zamsync-storage/Cargo.toml
+++ b/crates/zamsync-storage/Cargo.toml
@@ -17,3 +17,4 @@ rkyv.workspace = true
 tempfile.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+zamsync-testing = { path = "../zamsync-testing" }

--- a/crates/zamsync-storage/src/adapters/file_peer_store.rs
+++ b/crates/zamsync-storage/src/adapters/file_peer_store.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use zamsync_core::{NodeId, ReplicationState, VersionVector, ZamError, ZamResult};
 use zamsync_core::ports::PeerStore;
+use zamsync_core::{NodeId, ReplicationState, VersionVector, ZamError, ZamResult};
 
 pub struct FilePeerStore {
     path: PathBuf,
@@ -36,8 +36,8 @@ impl PeerStore for FilePeerStore {
     }
 
     fn save(&mut self, state: &ReplicationState) -> ZamResult<()> {
-        let bytes = rkyv::to_bytes::<_, 1024>(state)
-            .map_err(|e| ZamError::Serialization(e.to_string()))?;
+        let bytes =
+            rkyv::to_bytes::<_, 1024>(state).map_err(|e| ZamError::Serialization(e.to_string()))?;
         let mut file = OpenOptions::new()
             .create(true)
             .write(true)

--- a/crates/zamsync-storage/src/adapters/wal_event_store.rs
+++ b/crates/zamsync-storage/src/adapters/wal_event_store.rs
@@ -1,7 +1,7 @@
-use std::path::{Path, PathBuf};
-use zamsync_core::{Event, SequenceNumber, ZamError, ZamResult};
-use zamsync_core::ports::EventStore;
 use crate::wal::{WalScanner, WalWriter};
+use std::path::{Path, PathBuf};
+use zamsync_core::ports::EventStore;
+use zamsync_core::{Event, SequenceNumber, ZamError, ZamResult};
 
 pub struct WalEventStore {
     path: PathBuf,
@@ -26,8 +26,8 @@ impl EventStore for WalEventStore {
     }
 
     fn append(&mut self, event: &Event) -> ZamResult<SequenceNumber> {
-        let bytes = rkyv::to_bytes::<_, 1024>(event)
-            .map_err(|e| ZamError::Serialization(e.to_string()))?;
+        let bytes =
+            rkyv::to_bytes::<_, 1024>(event).map_err(|e| ZamError::Serialization(e.to_string()))?;
         self.writer.append(&bytes)
     }
 

--- a/crates/zamsync-storage/src/engine.rs
+++ b/crates/zamsync-storage/src/engine.rs
@@ -2,7 +2,7 @@ use crate::adapters::{FilePeerStore, WalEventStore};
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 use zamsync_core::ports::{EventStore, PeerStore, StateStore};
-use zamsync_core::{Event, Hlc, NodeId, ReplicationState, SequenceNumber, ZamResult};
+use zamsync_core::{Event, Hlc, NodeId, ReplicationState, SequenceNumber, SyncMessage, ZamResult};
 
 pub struct ZamEngine<E: EventStore, P: PeerStore, S: StateStore> {
     node_id: NodeId,
@@ -52,9 +52,89 @@ impl<E: EventStore, P: PeerStore, S: StateStore> ZamEngine<E, P, S> {
     }
 
     pub fn apply_replicated(&mut self, event: Event) -> ZamResult<SequenceNumber> {
+        if let Some(&last) = self.replication.local_vv.entries.get(&event.origin_node.0) {
+            if event.seq <= last {
+                return Ok(event.seq);
+            }
+        }
         let now_ms = now_ms();
         self.hlc.sync(now_ms, &event.hlc);
         self.commit_event(event)
+    }
+
+    /// Returns all events from `origin_node` with `seq >= start_seq`.
+    pub fn events_since(
+        &self,
+        origin_node: NodeId,
+        start_seq: SequenceNumber,
+    ) -> ZamResult<Vec<Event>> {
+        let events = self
+            .event_store
+            .scan()?
+            .filter_map(|r| r.ok())
+            .filter(|e| e.origin_node == origin_node && e.seq.0 >= start_seq.0)
+            .collect();
+        Ok(events)
+    }
+
+    /// Builds a Handshake message from our current replication state.
+    pub fn prepare_handshake(&self) -> SyncMessage {
+        SyncMessage::Handshake {
+            node_id: self.node_id,
+            vv: self.replication.local_vv.clone(),
+        }
+    }
+
+    /// Handles an incoming sync message and returns the response messages to send back.
+    pub fn handle_sync_message(
+        &mut self,
+        from: NodeId,
+        msg: SyncMessage,
+    ) -> ZamResult<Vec<SyncMessage>> {
+        match msg {
+            SyncMessage::Handshake { vv, .. } => {
+                let our_vv = self.replication.local_vv.clone();
+                let gaps = vv.find_gaps(&our_vv);
+                let mut responses = vec![self.prepare_handshake()];
+                for (node, start_seq) in gaps {
+                    let events = self.events_since(node, start_seq)?;
+                    if !events.is_empty() {
+                        responses.push(SyncMessage::EventBatch {
+                            origin_node: node,
+                            events,
+                        });
+                    }
+                }
+                responses.push(SyncMessage::SyncComplete);
+                Ok(responses)
+            }
+            SyncMessage::PullRequest {
+                origin_node,
+                start_seq,
+                limit,
+            } => {
+                let events = self
+                    .events_since(origin_node, start_seq)?
+                    .into_iter()
+                    .take(limit as usize)
+                    .collect();
+                Ok(vec![SyncMessage::EventBatch {
+                    origin_node,
+                    events,
+                }])
+            }
+            SyncMessage::EventBatch { events, .. } => {
+                for event in events {
+                    self.apply_replicated(event)?;
+                }
+                Ok(vec![])
+            }
+            SyncMessage::SyncComplete => {
+                self.replication.peers.entry(from.0).or_default().known_vv =
+                    self.replication.local_vv.clone();
+                Ok(vec![])
+            }
+        }
     }
 
     pub fn scan_events(&self) -> ZamResult<Box<dyn Iterator<Item = ZamResult<Event>>>> {

--- a/crates/zamsync-storage/src/engine.rs
+++ b/crates/zamsync-storage/src/engine.rs
@@ -1,8 +1,8 @@
+use crate::adapters::{FilePeerStore, WalEventStore};
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
-use zamsync_core::{Event, Hlc, NodeId, ReplicationState, SequenceNumber, ZamResult};
 use zamsync_core::ports::{EventStore, PeerStore, StateStore};
-use crate::adapters::{FilePeerStore, WalEventStore};
+use zamsync_core::{Event, Hlc, NodeId, ReplicationState, SequenceNumber, ZamResult};
 
 pub struct ZamEngine<E: EventStore, P: PeerStore, S: StateStore> {
     node_id: NodeId,
@@ -14,12 +14,7 @@ pub struct ZamEngine<E: EventStore, P: PeerStore, S: StateStore> {
 }
 
 impl<E: EventStore, P: PeerStore, S: StateStore> ZamEngine<E, P, S> {
-    pub fn new(
-        node_id: NodeId,
-        event_store: E,
-        peer_store: P,
-        mut state: S,
-    ) -> ZamResult<Self> {
+    pub fn new(node_id: NodeId, event_store: E, peer_store: P, mut state: S) -> ZamResult<Self> {
         let mut max_hlc = Hlc::default();
 
         for event_res in event_store.scan()? {
@@ -86,17 +81,15 @@ impl<E: EventStore, P: PeerStore, S: StateStore> ZamEngine<E, P, S> {
     fn commit_event(&mut self, event: Event) -> ZamResult<SequenceNumber> {
         let local_seq = self.event_store.append(&event)?;
         self.state.apply_event(local_seq, &event)?;
-        self.replication.local_vv.update(event.origin_node, event.seq);
+        self.replication
+            .local_vv
+            .update(event.origin_node, event.seq);
         Ok(local_seq)
     }
 }
 
 impl<S: StateStore> ZamEngine<WalEventStore, FilePeerStore, S> {
-    pub fn open_wal(
-        data_dir: impl AsRef<Path>,
-        node_id: NodeId,
-        state: S,
-    ) -> ZamResult<Self> {
+    pub fn open_wal(data_dir: impl AsRef<Path>, node_id: NodeId, state: S) -> ZamResult<Self> {
         let dir = data_dir.as_ref();
         let event_store = WalEventStore::open(dir.join("events.wal"))?;
         let peer_store = FilePeerStore::open(dir.join("peers.state"), node_id)?;

--- a/crates/zamsync-storage/src/lib.rs
+++ b/crates/zamsync-storage/src/lib.rs
@@ -1,11 +1,13 @@
 pub mod adapters;
 pub mod engine;
 pub mod sorter;
+pub mod sync_session;
 pub mod wal;
 
 pub use adapters::{FilePeerStore, WalEventStore};
 pub use engine::ZamEngine;
 pub use sorter::LogSorter;
+pub use sync_session::{SyncSession, SyncStats};
 pub use wal::{WalIterator, WalRecord, WalScanner, WalWriter};
 
 pub use zamsync_core::ports::{EventStore, PeerStore, StateStore, Transport};

--- a/crates/zamsync-storage/src/sorter.rs
+++ b/crates/zamsync-storage/src/sorter.rs
@@ -1,12 +1,12 @@
-use zamsync_core::{Event, ZamResult};
-use std::collections::BinaryHeap;
 use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+use zamsync_core::{Event, ZamResult};
 
 /// LogSorter is a mechanical merger that combines multiple event streams.
 /// It ensures that the output stream follows the deterministic global order rule.
-pub struct LogSorter<I> 
-where 
-    I: Iterator<Item = ZamResult<Event>>
+pub struct LogSorter<I>
+where
+    I: Iterator<Item = ZamResult<Event>>,
 {
     sources: Vec<std::iter::Peekable<I>>,
     heap: BinaryHeap<IndexedEvent>,
@@ -41,9 +41,9 @@ impl Ord for IndexedEvent {
     }
 }
 
-impl<I> LogSorter<I> 
-where 
-    I: Iterator<Item = ZamResult<Event>>
+impl<I> LogSorter<I>
+where
+    I: Iterator<Item = ZamResult<Event>>,
 {
     pub fn new(iterators: Vec<I>) -> ZamResult<Self> {
         let mut sources: Vec<_> = iterators.into_iter().map(|it| it.peekable()).collect();
@@ -53,7 +53,10 @@ where
         for (idx, source) in sources.iter_mut().enumerate() {
             if let Some(res) = source.next() {
                 let event = res?;
-                heap.push(IndexedEvent { event, source_idx: idx });
+                heap.push(IndexedEvent {
+                    event,
+                    source_idx: idx,
+                });
             }
         }
 
@@ -61,9 +64,9 @@ where
     }
 }
 
-impl<I> Iterator for LogSorter<I> 
-where 
-    I: Iterator<Item = ZamResult<Event>>
+impl<I> Iterator for LogSorter<I>
+where
+    I: Iterator<Item = ZamResult<Event>>,
 {
     type Item = ZamResult<Event>;
 
@@ -74,7 +77,10 @@ where
         if let Some(res) = self.sources[source_idx].next() {
             match res {
                 Ok(next_event) => {
-                    self.heap.push(IndexedEvent { event: next_event, source_idx });
+                    self.heap.push(IndexedEvent {
+                        event: next_event,
+                        source_idx,
+                    });
                 }
                 Err(e) => return Some(Err(e)),
             }

--- a/crates/zamsync-storage/src/sync_session.rs
+++ b/crates/zamsync-storage/src/sync_session.rs
@@ -1,0 +1,96 @@
+use zamsync_core::ports::{EventStore, PeerStore, StateStore, Transport};
+use zamsync_core::{NodeId, SyncMessage, ZamError, ZamResult};
+
+use crate::engine::ZamEngine;
+
+#[derive(Debug, Default)]
+pub struct SyncStats {
+    pub events_sent: usize,
+    pub events_received: usize,
+}
+
+pub struct SyncSession<'a, E, P, S, T>
+where
+    E: EventStore,
+    P: PeerStore,
+    S: StateStore,
+    T: Transport,
+{
+    engine: &'a mut ZamEngine<E, P, S>,
+    transport: &'a mut T,
+}
+
+impl<'a, E, P, S, T> SyncSession<'a, E, P, S, T>
+where
+    E: EventStore,
+    P: PeerStore,
+    S: StateStore,
+    T: Transport,
+{
+    pub fn new(engine: &'a mut ZamEngine<E, P, S>, transport: &'a mut T) -> Self {
+        Self { engine, transport }
+    }
+
+    /// Initiates a sync with `peer_id`: sends our handshake, processes the peer's
+    /// response (handshake + event batches + SyncComplete), then sends our own events
+    /// followed by SyncComplete.
+    pub fn sync(&mut self, peer_id: NodeId) -> ZamResult<SyncStats> {
+        let mut stats = SyncStats::default();
+
+        self.transport
+            .send(peer_id, &self.engine.prepare_handshake())?;
+
+        let peer_vv = self.wait_for_handshake(peer_id)?;
+
+        while let Some((from, msg)) = self.transport.receive()? {
+            if from != peer_id {
+                continue;
+            }
+            let is_complete = matches!(msg, SyncMessage::SyncComplete);
+            if let SyncMessage::EventBatch { ref events, .. } = msg {
+                stats.events_received += events.len();
+            }
+            self.engine.handle_sync_message(from, msg)?;
+            if is_complete {
+                break;
+            }
+        }
+
+        let our_vv = self.engine.replication_state().local_vv.clone();
+        let gaps = peer_vv.find_gaps(&our_vv);
+        for (node, start_seq) in gaps {
+            let events = self.engine.events_since(node, start_seq)?;
+            if !events.is_empty() {
+                stats.events_sent += events.len();
+                self.transport.send(
+                    peer_id,
+                    &SyncMessage::EventBatch {
+                        origin_node: node,
+                        events,
+                    },
+                )?;
+            }
+        }
+        self.transport.send(peer_id, &SyncMessage::SyncComplete)?;
+
+        self.engine.sync()?;
+        Ok(stats)
+    }
+
+    fn wait_for_handshake(
+        &mut self,
+        expected_peer: NodeId,
+    ) -> ZamResult<zamsync_core::VersionVector> {
+        for _ in 0..10_000 {
+            match self.transport.receive()? {
+                Some((from, SyncMessage::Handshake { vv, .. })) if from == expected_peer => {
+                    return Ok(vv);
+                }
+                Some(_) | None => continue,
+            }
+        }
+        Err(ZamError::Protocol(
+            "timeout waiting for peer handshake".into(),
+        ))
+    }
+}

--- a/crates/zamsync-storage/src/wal.rs
+++ b/crates/zamsync-storage/src/wal.rs
@@ -1,9 +1,9 @@
-use std::fs::{File, OpenOptions};
-use std::io::{self, Write, Read, Seek, SeekFrom, BufWriter};
-use std::path::Path;
-use byteorder::{BigEndian, WriteBytesExt, ReadBytesExt};
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use crc32fast::Hasher;
-use zamsync_core::{SequenceNumber, ZamResult, ZamError, WAL_MAGIC, WAL_VERSION};
+use std::fs::{File, OpenOptions};
+use std::io::{self, BufWriter, Read, Seek, SeekFrom, Write};
+use std::path::Path;
+use zamsync_core::{SequenceNumber, ZamError, ZamResult, WAL_MAGIC, WAL_VERSION};
 
 /// WAL Header Size: 4 (Magic) + 1 (Ver) + 4 (CRC) + 8 (Seq) + 4 (Len) = 21 bytes.
 pub const WAL_HEADER_SIZE: usize = 21;
@@ -23,11 +23,8 @@ impl WalWriter {
     /// Opens or creates a WAL file.
     /// If it exists, it MUST be validated first to ensure no partial records at the end.
     pub fn open(path: impl AsRef<Path>, start_seq: SequenceNumber) -> ZamResult<Self> {
-        let file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(path)?;
-        
+        let file = OpenOptions::new().create(true).append(true).open(path)?;
+
         Ok(Self {
             file: BufWriter::new(file),
             current_seq: start_seq,
@@ -129,27 +126,30 @@ impl Iterator for WalIterator {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.file.seek(SeekFrom::Start(self.offset)).ok()?;
-        
+
         let mut header = [0u8; WAL_HEADER_SIZE];
         let bytes_read = self.file.read(&mut header).ok()?;
-        
+
         if bytes_read == 0 {
             return None;
         }
-        
+
         if bytes_read < WAL_HEADER_SIZE {
             return Some(Err(ZamError::Corruption("Partial header at EOF".into())));
         }
 
         let mut rdr = io::Cursor::new(&header);
-        
+
         // 1. Verify Magic
         let mut magic = [0u8; 4];
         if let Err(e) = rdr.read_exact(&mut magic) {
             return Some(Err(e.into()));
         }
         if magic != WAL_MAGIC {
-            return Some(Err(ZamError::Corruption(format!("Invalid magic: {:?}", magic))));
+            return Some(Err(ZamError::Corruption(format!(
+                "Invalid magic: {:?}",
+                magic
+            ))));
         }
 
         // 2. Read Metadata
@@ -158,9 +158,12 @@ impl Iterator for WalIterator {
             Err(e) => return Some(Err(e.into())),
         };
         if version != WAL_VERSION {
-            return Some(Err(ZamError::Corruption(format!("Unsupported version: {}", version))));
+            return Some(Err(ZamError::Corruption(format!(
+                "Unsupported version: {}",
+                version
+            ))));
         }
-        
+
         let expected_crc = match rdr.read_u32::<BigEndian>() {
             Ok(v) => v,
             Err(e) => return Some(Err(e.into())),
@@ -207,14 +210,14 @@ impl Iterator for WalIterator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::tempdir;
     use std::io::Write;
+    use tempfile::tempdir;
 
     #[test]
     fn test_wal_roundtrip() -> ZamResult<()> {
         let dir = tempdir()?;
         let path = dir.path().join("test.wal");
-        
+
         let mut writer = WalWriter::open(&path, SequenceNumber::ZERO)?;
         writer.append(b"hello")?;
         writer.append(b"world")?;
@@ -222,7 +225,7 @@ mod tests {
 
         let scanner = WalScanner::open(&path)?;
         let mut it = scanner.scan();
-        
+
         let r1 = it.next().unwrap().unwrap();
         assert_eq!(r1.seq.0, 0);
         assert_eq!(r1.payload, b"hello");
@@ -237,7 +240,7 @@ mod tests {
     fn test_wal_recovery_partial_write() -> ZamResult<()> {
         let dir = tempdir()?;
         let path = dir.path().join("test.wal");
-        
+
         {
             let mut writer = WalWriter::open(&path, SequenceNumber::ZERO)?;
             writer.append(b"valid")?;
@@ -265,7 +268,7 @@ mod tests {
     fn test_wal_corruption_detection() -> ZamResult<()> {
         let dir = tempdir()?;
         let path = dir.path().join("test.wal");
-        
+
         let mut writer = WalWriter::open(&path, SequenceNumber::ZERO)?;
         writer.append(b"perfect")?;
         writer.sync()?;
@@ -280,7 +283,7 @@ mod tests {
         let scanner = WalScanner::open(&path)?;
         let mut it = scanner.scan();
         let res = it.next().unwrap();
-        
+
         match res {
             Err(ZamError::Corruption(msg)) => assert!(msg.contains("CRC mismatch")),
             _ => panic!("Expected CRC mismatch error, got {:?}", res),

--- a/crates/zamsync-storage/tests/convergence_test.rs
+++ b/crates/zamsync-storage/tests/convergence_test.rs
@@ -1,8 +1,8 @@
-use zamsync_core::{Event, NodeId, SequenceNumber, ZamResult};
-use zamsync_core::ports::StateStore;
-use zamsync_storage::{FilePeerStore, LogSorter, WalEventStore, ZamEngine};
-use tempfile::tempdir;
 use std::collections::HashMap;
+use tempfile::tempdir;
+use zamsync_core::ports::StateStore;
+use zamsync_core::{Event, NodeId, SequenceNumber, ZamResult};
+use zamsync_storage::{FilePeerStore, LogSorter, WalEventStore, ZamEngine};
 
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 struct KVState {
@@ -13,7 +13,8 @@ struct KVState {
 impl StateStore for KVState {
     fn apply_event(&mut self, _seq: SequenceNumber, event: &Event) -> ZamResult<()> {
         let val = String::from_utf8_lossy(&event.payload).to_string();
-        self.data.insert(format!("node_{}", event.origin_node.0), val.clone());
+        self.data
+            .insert(format!("node_{}", event.origin_node.0), val.clone());
         self.history.push(val);
         Ok(())
     }
@@ -65,8 +66,14 @@ fn test_split_brain_convergence() -> Result<(), Box<dyn std::error::Error>> {
         final_state_b.apply_event(SequenceNumber(i as u64), &event_res?)?;
     }
 
-    assert_eq!(final_state_a.history, final_state_b.history, "convergence path diverged");
-    assert_eq!(final_state_a, final_state_b, "final states are not identical");
+    assert_eq!(
+        final_state_a.history, final_state_b.history,
+        "convergence path diverged"
+    );
+    assert_eq!(
+        final_state_a, final_state_b,
+        "final states are not identical"
+    );
 
     Ok(())
 }

--- a/crates/zamsync-storage/tests/engine_test.rs
+++ b/crates/zamsync-storage/tests/engine_test.rs
@@ -1,8 +1,8 @@
-use zamsync_core::{Event, Hlc, NodeId, SequenceNumber, ZamResult};
-use zamsync_core::ports::StateStore;
-use zamsync_storage::{FilePeerStore, WalEventStore, ZamEngine};
-use tempfile::tempdir;
 use std::collections::HashMap;
+use tempfile::tempdir;
+use zamsync_core::ports::StateStore;
+use zamsync_core::{Event, Hlc, NodeId, SequenceNumber, ZamResult};
+use zamsync_storage::{FilePeerStore, WalEventStore, ZamEngine};
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
 enum DomainEvent {

--- a/crates/zamsync-storage/tests/peer_test.rs
+++ b/crates/zamsync-storage/tests/peer_test.rs
@@ -48,6 +48,8 @@ fn test_vv_gap_discovery() {
 
     let gaps = local.find_gaps(&remote);
     assert_eq!(gaps.len(), 2);
-    assert!(gaps.iter().any(|(id, seq)| id.0 == 1 && seq.0 == 10));
+    // local has node 1 up to seq 10, remote has up to 12 -> next needed: seq 11
+    assert!(gaps.iter().any(|(id, seq)| id.0 == 1 && seq.0 == 11));
+    // local has never seen node 3 -> start from seq 0 inclusive
     assert!(gaps.iter().any(|(id, seq)| id.0 == 3 && seq.0 == 0));
 }

--- a/crates/zamsync-storage/tests/peer_test.rs
+++ b/crates/zamsync-storage/tests/peer_test.rs
@@ -1,7 +1,7 @@
-use zamsync_core::{NodeId, SequenceNumber, VersionVector};
-use zamsync_core::ports::PeerStore;
-use zamsync_storage::FilePeerStore;
 use tempfile::tempdir;
+use zamsync_core::ports::PeerStore;
+use zamsync_core::{NodeId, SequenceNumber, VersionVector};
+use zamsync_storage::FilePeerStore;
 
 #[test]
 fn test_version_vector_persistence() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/zamsync-storage/tests/sorter_test.rs
+++ b/crates/zamsync-storage/tests/sorter_test.rs
@@ -50,7 +50,7 @@ fn test_log_sorter_deterministic_merge() -> Result<(), Box<dyn std::error::Error
     // 2. b1 (HLC 102,0)
     // 3. a2 (HLC 105,0)
     // 4. b2 (HLC 105,1)
-    
+
     assert_eq!(results[0].payload, b"a1");
     assert_eq!(results[1].payload, b"b1");
     assert_eq!(results[2].payload, b"a2");
@@ -85,12 +85,12 @@ fn test_log_sorter_tie_break_with_node_id() -> Result<(), Box<dyn std::error::Er
     let results: Vec<Event> = sorter.collect::<ZamResult<Vec<_>>>()?;
 
     // Deterministic tie-break: Node 1 before Node 2 (assuming lower NodeId comes first in our Ord impl)
-    // My Ord impl for IndexedEvent: 
+    // My Ord impl for IndexedEvent:
     // match self.event.hlc.cmp(&other.event.hlc) {
     //     Ordering::Equal => other.event.origin_node.0.cmp(&self.event.origin_node.0), // Reverted for Min-Heap
     //     other_order => other_order.reverse(),
     // }
-    
+
     // other.origin_node.0.cmp(&self.origin_node.0)
     // If self is 1 and other is 2: 2.cmp(1) = Greater. So self (1) is "smaller" in the heap logic.
     // Correct. Node 1 should come before Node 2.

--- a/crates/zamsync-storage/tests/sync_test.rs
+++ b/crates/zamsync-storage/tests/sync_test.rs
@@ -1,0 +1,170 @@
+use zamsync_core::ports::StateStore;
+use zamsync_core::{Event, NodeId, SequenceNumber, SyncMessage, VersionVector, ZamResult};
+use zamsync_storage::ZamEngine;
+use zamsync_testing::{run_direct_sync, InMemoryEventStore, InMemoryPeerStore};
+
+#[derive(Default)]
+struct NoopState;
+
+impl StateStore for NoopState {
+    fn apply_event(&mut self, _seq: SequenceNumber, _event: &Event) -> ZamResult<()> {
+        Ok(())
+    }
+    fn last_applied_seq(&self) -> Option<SequenceNumber> {
+        None
+    }
+}
+
+fn make_engine(
+    node_id: NodeId,
+) -> ZamResult<ZamEngine<InMemoryEventStore, InMemoryPeerStore, NoopState>> {
+    ZamEngine::new(
+        node_id,
+        InMemoryEventStore::default(),
+        InMemoryPeerStore::new(node_id),
+        NoopState,
+    )
+}
+
+#[test]
+fn test_direct_sync_convergence() -> Result<(), Box<dyn std::error::Error>> {
+    let node_a = NodeId(1);
+    let node_b = NodeId(2);
+
+    let mut engine_a = make_engine(node_a)?;
+    let mut engine_b = make_engine(node_b)?;
+
+    engine_a.submit(1, b"a-event-1".to_vec())?;
+    engine_a.submit(1, b"a-event-2".to_vec())?;
+    engine_b.submit(1, b"b-event-1".to_vec())?;
+
+    let (applied_to_a, applied_to_b) = run_direct_sync(&mut engine_a, &mut engine_b)?;
+
+    assert_eq!(applied_to_a, 1, "A should receive 1 event from B");
+    assert_eq!(applied_to_b, 2, "B should receive 2 events from A");
+
+    let vv_a = engine_a.replication_state().local_vv.clone();
+    let vv_b = engine_b.replication_state().local_vv.clone();
+    assert_eq!(
+        vv_a.entries.get(&node_a.0),
+        vv_b.entries.get(&node_a.0),
+        "VV for node A must agree"
+    );
+    assert_eq!(
+        vv_a.entries.get(&node_b.0),
+        vv_b.entries.get(&node_b.0),
+        "VV for node B must agree"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_direct_sync_idempotent() -> Result<(), Box<dyn std::error::Error>> {
+    let node_a = NodeId(1);
+    let node_b = NodeId(2);
+
+    let mut engine_a = make_engine(node_a)?;
+    let mut engine_b = make_engine(node_b)?;
+
+    engine_a.submit(1, b"x".to_vec())?;
+
+    run_direct_sync(&mut engine_a, &mut engine_b)?;
+    let (a2, b2) = run_direct_sync(&mut engine_a, &mut engine_b)?;
+
+    assert_eq!(a2, 0, "second sync should transfer nothing to A");
+    assert_eq!(b2, 0, "second sync should transfer nothing to B");
+
+    Ok(())
+}
+
+#[test]
+fn test_handle_sync_message_handshake() -> Result<(), Box<dyn std::error::Error>> {
+    let node_a = NodeId(1);
+    let node_b = NodeId(2);
+
+    let mut engine_a = make_engine(node_a)?;
+    let engine_b = make_engine(node_b)?;
+
+    engine_a.submit(1, b"e1".to_vec())?;
+    engine_a.submit(1, b"e2".to_vec())?;
+    engine_a.submit(1, b"e3".to_vec())?;
+
+    let peer_vv = engine_b.replication_state().local_vv.clone();
+    let handshake = SyncMessage::Handshake {
+        node_id: node_b,
+        vv: peer_vv,
+    };
+
+    let responses = engine_a.handle_sync_message(node_b, handshake)?;
+
+    assert!(
+        responses.len() >= 2,
+        "expected at least Handshake + SyncComplete, got {}",
+        responses.len()
+    );
+
+    let has_handshake = responses
+        .iter()
+        .any(|m| matches!(m, SyncMessage::Handshake { .. }));
+    assert!(has_handshake, "response must include a Handshake");
+
+    let total_events: usize = responses
+        .iter()
+        .filter_map(|m| {
+            if let SyncMessage::EventBatch { events, .. } = m {
+                Some(events.len())
+            } else {
+                None
+            }
+        })
+        .sum();
+    assert_eq!(total_events, 3, "expected all 3 events in response batches");
+
+    let last = responses.last().unwrap();
+    assert!(
+        matches!(last, SyncMessage::SyncComplete),
+        "last message must be SyncComplete"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_handle_sync_message_empty_handshake() -> Result<(), Box<dyn std::error::Error>> {
+    let node_a = NodeId(1);
+    let node_b = NodeId(2);
+
+    let mut engine_a = make_engine(node_a)?;
+
+    engine_a.submit(1, b"x".to_vec())?;
+
+    let mut full_vv = VersionVector::default();
+    full_vv.update(node_a, SequenceNumber(0));
+
+    let responses = engine_a.handle_sync_message(
+        node_b,
+        SyncMessage::Handshake {
+            node_id: node_b,
+            vv: full_vv,
+        },
+    )?;
+
+    let total_events: usize = responses
+        .iter()
+        .filter_map(|m| {
+            if let SyncMessage::EventBatch { events, .. } = m {
+                Some(events.len())
+            } else {
+                None
+            }
+        })
+        .sum();
+    assert_eq!(
+        total_events, 0,
+        "peer is up-to-date, no events should be sent"
+    );
+    assert!(matches!(responses.last(), Some(SyncMessage::SyncComplete)));
+
+    Ok(())
+}

--- a/crates/zamsync-testing/Cargo.toml
+++ b/crates/zamsync-testing/Cargo.toml
@@ -8,3 +8,4 @@ description.workspace = true
 
 [dependencies]
 zamsync-core = { path = "../zamsync-core" }
+zamsync-storage = { path = "../zamsync-storage" }

--- a/crates/zamsync-testing/src/adapters/in_memory_event_store.rs
+++ b/crates/zamsync-testing/src/adapters/in_memory_event_store.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
-use zamsync_core::{Event, SequenceNumber, ZamResult};
 use zamsync_core::ports::EventStore;
+use zamsync_core::{Event, SequenceNumber, ZamResult};
 
 #[derive(Default, Clone)]
 pub struct InMemoryEventStore {

--- a/crates/zamsync-testing/src/adapters/in_memory_peer_store.rs
+++ b/crates/zamsync-testing/src/adapters/in_memory_peer_store.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
-use zamsync_core::{NodeId, ReplicationState, VersionVector, ZamResult};
 use zamsync_core::ports::PeerStore;
+use zamsync_core::{NodeId, ReplicationState, VersionVector, ZamResult};
 
 pub struct InMemoryPeerStore {
     state: ReplicationState,

--- a/crates/zamsync-testing/src/adapters/mock_transport.rs
+++ b/crates/zamsync-testing/src/adapters/mock_transport.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
-use zamsync_core::{NodeId, SyncMessage, ZamResult};
 use zamsync_core::ports::Transport;
+use zamsync_core::{NodeId, SyncMessage, ZamResult};
 
 pub struct MockTransport {
     outbox: Vec<(NodeId, SyncMessage)>,

--- a/crates/zamsync-testing/src/lib.rs
+++ b/crates/zamsync-testing/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod adapters;
+pub mod sync;
 
 pub use adapters::{InMemoryEventStore, InMemoryPeerStore, MockTransport};
+pub use sync::run_direct_sync;

--- a/crates/zamsync-testing/src/sync.rs
+++ b/crates/zamsync-testing/src/sync.rs
@@ -1,0 +1,41 @@
+use zamsync_core::ports::{EventStore, PeerStore, StateStore};
+use zamsync_core::ZamResult;
+use zamsync_storage::ZamEngine;
+
+/// Synchronises two engines in both directions without a transport layer.
+/// Returns `(events_applied_to_a, events_applied_to_b)`.
+///
+/// Useful for convergence tests that do not need to exercise the wire protocol.
+pub fn run_direct_sync<E1, P1, S1, E2, P2, S2>(
+    engine_a: &mut ZamEngine<E1, P1, S1>,
+    engine_b: &mut ZamEngine<E2, P2, S2>,
+) -> ZamResult<(usize, usize)>
+where
+    E1: EventStore,
+    P1: PeerStore,
+    S1: StateStore,
+    E2: EventStore,
+    P2: PeerStore,
+    S2: StateStore,
+{
+    let vv_a = engine_a.replication_state().local_vv.clone();
+    let vv_b = engine_b.replication_state().local_vv.clone();
+
+    let mut applied_to_a = 0;
+    for (node, start_seq) in vv_a.find_gaps(&vv_b) {
+        for event in engine_b.events_since(node, start_seq)? {
+            engine_a.apply_replicated(event)?;
+            applied_to_a += 1;
+        }
+    }
+
+    let mut applied_to_b = 0;
+    for (node, start_seq) in vv_b.find_gaps(&vv_a) {
+        for event in engine_a.events_since(node, start_seq)? {
+            engine_b.apply_replicated(event)?;
+            applied_to_b += 1;
+        }
+    }
+
+    Ok((applied_to_a, applied_to_b))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,103 @@
-fn main() {
-    println!("Hello, world!");
+use std::env;
+use std::path::PathBuf;
+use zamsync_core::ports::StateStore;
+use zamsync_core::{Event, NodeId, SequenceNumber, ZamResult};
+use zamsync_storage::ZamEngine;
+
+#[derive(Default)]
+struct EventCounter {
+    count: usize,
+    last_seq: Option<SequenceNumber>,
+}
+
+impl StateStore for EventCounter {
+    fn apply_event(&mut self, seq: SequenceNumber, _event: &Event) -> ZamResult<()> {
+        self.count += 1;
+        self.last_seq = Some(seq);
+        Ok(())
+    }
+    fn last_applied_seq(&self) -> Option<SequenceNumber> {
+        self.last_seq
+    }
+}
+
+fn usage() {
+    eprintln!(
+        "Usage:
+  zamsync info <data-dir>          Show node status
+  zamsync submit <data-dir> <msg>  Append an event with a text payload"
+    );
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = env::args().collect();
+
+    match args.get(1).map(String::as_str) {
+        Some("info") => {
+            let dir = data_dir(&args, 2)?;
+            let node_id = node_id_from_dir(&dir);
+            let engine = ZamEngine::open_wal(&dir, node_id, EventCounter::default())?;
+
+            println!("node_id  : {}", node_id.0);
+            println!("data_dir : {}", dir.display());
+            println!("events   : {}", engine.state().count);
+            let vv = &engine.replication_state().local_vv;
+            if vv.entries.is_empty() {
+                println!("vv       : (empty)");
+            } else {
+                for (node, seq) in &vv.entries {
+                    println!("vv       : node {} @ seq {}", node, seq.0);
+                }
+            }
+        }
+        Some("submit") => {
+            let dir = data_dir(&args, 2)?;
+            let payload = args
+                .get(3)
+                .ok_or("missing payload argument")?
+                .as_bytes()
+                .to_vec();
+            let node_id = node_id_from_dir(&dir);
+            let mut engine = ZamEngine::open_wal(&dir, node_id, EventCounter::default())?;
+            let seq = engine.submit(1, payload)?;
+            engine.sync()?;
+            println!("submitted seq={}", seq.0);
+        }
+        _ => {
+            usage();
+            std::process::exit(1);
+        }
+    }
+
+    Ok(())
+}
+
+fn data_dir(args: &[String], pos: usize) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let path = PathBuf::from(args.get(pos).ok_or("missing data-dir argument")?);
+    std::fs::create_dir_all(&path)?;
+    Ok(path)
+}
+
+fn node_id_from_dir(dir: &std::path::Path) -> NodeId {
+    let id_file = dir.join(".node_id");
+    if let Ok(bytes) = std::fs::read(&id_file) {
+        if let Ok(s) = std::str::from_utf8(&bytes) {
+            if let Ok(n) = s.trim().parse::<u32>() {
+                return NodeId(n);
+            }
+        }
+    }
+    let id: u32 = rand_u32();
+    let _ = std::fs::write(&id_file, id.to_string());
+    NodeId(id)
+}
+
+fn rand_u32() -> u32 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    use std::time::SystemTime;
+    let mut h = DefaultHasher::new();
+    SystemTime::now().hash(&mut h);
+    std::process::id().hash(&mut h);
+    h.finish() as u32
 }


### PR DESCRIPTION
## Summary

- **Hexagonal architecture**: port traits (`EventStore`, `PeerStore`, `StateStore`, `Transport`) defined in `zamsync-core::ports`; all I/O flows through traits, engine has zero filesystem or network code
- **Sync protocol**: `find_gaps` returns inclusive `start_seq`; `SyncMessage::SyncComplete` signals end of transmission; `handle_sync_message` is a pure state-machine handler returning response messages; `apply_replicated` is idempotent via VV check
- **Storage adapters**: `WalEventStore` (WAL-backed `EventStore`) and `FilePeerStore` (rkyv-serialized `PeerStore`)
- **Network adapter**: `TcpTransport` + binary wire protocol (4-byte length-prefixed rkyv frames)
- **Testing crate**: `InMemoryEventStore`, `InMemoryPeerStore`, `MockTransport`, and `run_direct_sync` for transport-free convergence tests
- **Sync session**: `SyncSession` drives the full protocol over any `Transport`; `run_direct_sync` for tests
- **CI**: GitHub Actions with `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test --workspace` on every push/PR
- **CLI**: `zamsync info ` and `zamsync submit  ` backed by `ZamEngine::open_wal`
- **Docs**: `ARCHITECTURE.md` updated with port/adapter tables, sync protocol diagram, gap semantics; `README.md` updated with crate layout, quick start, and usage example

## Test plan

- [ ] CI passes (fmt + clippy + test)
- [ ] `cargo test --workspace` -- 19 tests across 14 suites, all green
- [ ] `test_direct_sync_convergence`: A and B write concurrently, `run_direct_sync` fully converges both
- [ ] `test_direct_sync_idempotent`: second sync transfers zero events
- [ ] `test_handle_sync_message_handshake`: response includes Handshake + 3 EventBatch events + SyncComplete
- [ ] `test_handle_sync_message_empty_handshake`: up-to-date peer triggers no EventBatch