### PR TITLE
feat: end-to-end TCP sync, serve/sync CLI, sorted replay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,12 +143,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "env_filter"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -223,10 +311,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "js-sys"
@@ -277,10 +395,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "prettyplease"
@@ -341,6 +480,35 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rend"
@@ -553,6 +721,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -795,8 +969,10 @@ dependencies = [
 name = "zamsync"
 version = "0.1.0"
 dependencies = [
+ "env_logger",
  "log",
  "zamsync-core",
+ "zamsync-network",
  "zamsync-storage",
 ]
 
@@ -817,7 +993,9 @@ dependencies = [
  "byteorder",
  "log",
  "rkyv",
+ "tempfile",
  "zamsync-core",
+ "zamsync-storage",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,10 @@ description = "Resilient Offline-First Synchronization Engine"
 
 [dependencies]
 zamsync-storage = { path = "crates/zamsync-storage" }
+zamsync-network = { path = "crates/zamsync-network" }
 zamsync-core = { path = "crates/zamsync-core" }
 log.workspace = true
+env_logger = "0.11"
 
 [workspace.dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,27 +1,65 @@
 # ZamSync Roadmap
 
-## 🟢 Phase 0-1: Foundation & Local Persistence (In Progress)
-- [x] Workspace Initialization
-- [x] Core Type Definitions (`SequenceNumber`, `NodeId`)
-- [x] Production-Grade WAL (Atomic-like appends, CRC32, Recovery)
-- [ ] Crash-Consistency Testing Suite
+## Phase 0: Foundation (done)
 
-## 🟡 Phase 1: Event Model & State Machine
-- [ ] Binary Event Schema (using `rkyv` for zero-copy)
-- [ ] Local State Projection (Queryable view of the WAL)
-- [ ] Engine Coordination (Applying WAL events to state)
+- [x] Workspace initialization and architecture documentation
+- [x] Core type definitions: `NodeId`, `SequenceNumber`, `Hlc`
+- [x] Production-grade WAL: atomic appends, CRC32 integrity, crash recovery
+- [x] rkyv zero-copy event schema
 
-## 🔴 Phase 2: Synchronization Protocol
-- [ ] Version Vectors / HLC implementation
-- [ ] Delta Sync Algorithm (Identifying missing event ranges)
-- [ ] Conflict Resolution Strategy (LWW / CRDT-lite)
+## Phase 1: Hexagonal Architecture (done)
 
-## 🔴 Phase 3: Resilient Transport
-- [ ] Custom Binary Protocol (Optimized headers)
-- [ ] Chunking & Resumable Transfer Mechanism
-- [ ] Adaptive Backoff for unstable networks
+- [x] Port traits: `EventStore`, `PeerStore`, `StateStore`, `Transport`
+- [x] Storage adapters: `WalEventStore`, `FilePeerStore`
+- [x] Testing adapters: `InMemoryEventStore`, `InMemoryPeerStore`, `MockTransport`
+- [x] `ZamEngine<E, P, S>` generic over all I/O
+- [x] `ZamEngine::sorted_scan` -- deterministic multi-node replay via `LogSorter`
+- [x] GitHub Actions CI: fmt + clippy -D warnings + test
 
-## 🔴 Phase 4: Hardening & Performance
-- [ ] Zstd Compression with pre-shared dictionaries
-- [ ] End-to-End Encryption
-- [ ] Resource profiling (< 100MB RAM target)
+## Phase 2: Sync Protocol (done)
+
+- [x] Version Vectors with `find_gaps` (inclusive start_seq semantics)
+- [x] HLC-based total ordering and `LogSorter` k-way merge
+- [x] `SyncMessage` enum: Handshake, PullRequest, EventBatch, SyncComplete
+- [x] `ZamEngine::handle_sync_message` -- server-side state machine
+- [x] `SyncSession::sync` -- initiator-side protocol
+- [x] `SyncSession::serve_one` -- responder-side protocol
+- [x] `run_direct_sync` in `zamsync-testing` for transport-free tests
+- [x] Idempotent `apply_replicated` with VV-based dedup
+
+## Phase 3: Transport (done)
+
+- [x] Binary wire protocol: 4-byte big-endian length prefix + rkyv payload
+- [x] `TcpTransport`: non-blocking listener, `accept_peer`, `connect`
+- [x] End-to-end TCP sync test: two nodes over loopback, full convergence verified
+- [x] CLI: `info`, `submit`, `sync <peer-addr> <peer-id>`, `serve <bind-addr> <peer-id>`
+
+## Phase 4: Hardening (next)
+
+- [ ] Crash-consistency test suite: simulate WAL truncation mid-write, verify recovery
+- [ ] `serve` loop: handle multiple sequential peers (not just one-shot)
+- [ ] Reconnect and retry logic in `SyncSession`
+- [ ] Max frame size enforcement and backpressure
+- [ ] Structured logging (tracing spans per sync session)
+
+## Phase 5: Performance
+
+- [ ] Zstd compression with pre-shared dictionary (target: -70% bandwidth on repetitive payloads)
+- [ ] Streaming `EventBatch` (chunked sends instead of full-collect)
+- [ ] WAL compaction / snapshot to bound replay time on startup
+- [ ] Resource profiling: target < 100 MB RSS on embedded hardware
+
+## Phase 6: Security and Ops
+
+- [ ] End-to-end encryption (noise protocol or TLS)
+- [ ] Node authentication (pre-shared keys or certificate pinning)
+- [ ] Prometheus metrics: events/s, sync latency, VV drift
+- [ ] Docker image + systemd unit for unattended deployment
+
+## First-Deployment Target
+
+Bhutan ePIS (electronic patient information system):
+- Clinics sync patient records over intermittent satellite / 2G links
+- Nodes run on low-cost ARM hardware (Raspberry Pi class)
+- Payload: structured JSON domain events, typically 1-10 KB each
+- Acceptable sync latency: minutes to hours depending on connectivity

--- a/crates/zamsync-network/Cargo.toml
+++ b/crates/zamsync-network/Cargo.toml
@@ -11,3 +11,7 @@ zamsync-core = { path = "../zamsync-core" }
 rkyv.workspace = true
 byteorder.workspace = true
 log.workspace = true
+
+[dev-dependencies]
+zamsync-storage = { path = "../zamsync-storage" }
+tempfile.workspace = true

--- a/crates/zamsync-network/src/transport/tcp.rs
+++ b/crates/zamsync-network/src/transport/tcp.rs
@@ -1,7 +1,7 @@
 use crate::protocol;
 use std::collections::HashMap;
 use std::io::BufWriter;
-use std::net::{TcpListener, TcpStream};
+use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::time::Duration;
 use zamsync_core::ports::Transport;
 use zamsync_core::{NodeId, SyncMessage, ZamError, ZamResult};
@@ -22,9 +22,25 @@ impl TcpTransport {
         })
     }
 
+    /// Returns the local address the listener is bound to.
+    pub fn local_addr(&self) -> ZamResult<SocketAddr> {
+        Ok(self.listener.local_addr()?)
+    }
+
+    /// Blocking accept: waits for one incoming connection and registers it as `peer_id`.
+    pub fn accept_peer(&mut self, peer_id: NodeId) -> ZamResult<()> {
+        self.listener.set_nonblocking(false)?;
+        let (stream, addr) = self.listener.accept()?;
+        self.listener.set_nonblocking(true)?;
+        stream.set_read_timeout(Some(Duration::from_millis(50)))?;
+        self.peers.insert(peer_id.0, stream);
+        log::info!("accepted peer {} from {}", peer_id.0, addr);
+        Ok(())
+    }
+
     pub fn connect(&mut self, peer_id: NodeId, addr: &str) -> ZamResult<()> {
         let stream = TcpStream::connect(addr)?;
-        stream.set_read_timeout(Some(Duration::from_millis(10)))?;
+        stream.set_read_timeout(Some(Duration::from_millis(50)))?;
         self.peers.insert(peer_id.0, stream);
         log::info!("connected to peer {} at {}", peer_id.0, addr);
         Ok(())
@@ -46,16 +62,6 @@ impl Transport for TcpTransport {
     }
 
     fn receive(&mut self) -> ZamResult<Option<(NodeId, SyncMessage)>> {
-        match self.listener.accept() {
-            Ok((stream, addr)) => {
-                log::debug!("incoming connection from {}", addr);
-                stream.set_read_timeout(Some(Duration::from_millis(10)))?;
-                drop(stream);
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
-            Err(e) => return Err(e.into()),
-        }
-
         let peer_ids: Vec<u32> = self.peers.keys().cloned().collect();
         for peer_id_raw in peer_ids {
             if let Some(stream) = self.peers.get_mut(&peer_id_raw) {
@@ -63,12 +69,14 @@ impl Transport for TcpTransport {
                     Ok(msg) => return Ok(Some((NodeId(peer_id_raw), msg))),
                     Err(ZamError::Io(e))
                         if e.kind() == std::io::ErrorKind::WouldBlock
-                            || e.kind() == std::io::ErrorKind::TimedOut => {}
+                            || e.kind() == std::io::ErrorKind::TimedOut =>
+                    {
+                        continue;
+                    }
                     Err(e) => return Err(e),
                 }
             }
         }
-
         Ok(None)
     }
 }

--- a/crates/zamsync-network/tests/tcp_sync_test.rs
+++ b/crates/zamsync-network/tests/tcp_sync_test.rs
@@ -1,0 +1,144 @@
+use std::sync::mpsc;
+use tempfile::tempdir;
+use zamsync_core::ports::StateStore;
+use zamsync_core::{Event, NodeId, SequenceNumber, ZamResult};
+use zamsync_network::TcpTransport;
+use zamsync_storage::{FilePeerStore, SyncSession, WalEventStore, ZamEngine};
+
+#[derive(Default)]
+struct EventCounter {
+    count: usize,
+}
+
+impl StateStore for EventCounter {
+    fn apply_event(&mut self, _seq: SequenceNumber, _event: &Event) -> ZamResult<()> {
+        self.count += 1;
+        Ok(())
+    }
+    fn last_applied_seq(&self) -> Option<SequenceNumber> {
+        None
+    }
+}
+
+fn open_engine(
+    dir: &tempfile::TempDir,
+    node_id: NodeId,
+) -> ZamResult<ZamEngine<WalEventStore, FilePeerStore, EventCounter>> {
+    ZamEngine::open_wal(dir.path(), node_id, EventCounter::default())
+}
+
+/// Two nodes sync over a loopback TCP connection.
+/// A serves (responder), B initiates (initiator).
+/// After sync both must have the same number of events.
+#[test]
+fn test_tcp_sync_end_to_end() -> Result<(), Box<dyn std::error::Error>> {
+    let node_a = NodeId(1);
+    let node_b = NodeId(2);
+
+    let dir_a = tempdir()?;
+    let dir_b = tempdir()?;
+
+    // Pre-populate both engines before connecting.
+    {
+        let mut engine = open_engine(&dir_a, node_a)?;
+        engine.submit(1, b"a-event-1".to_vec())?;
+        engine.submit(1, b"a-event-2".to_vec())?;
+        engine.sync()?;
+    }
+    {
+        let mut engine = open_engine(&dir_b, node_b)?;
+        engine.submit(1, b"b-event-1".to_vec())?;
+        engine.sync()?;
+    }
+
+    // A binds first; send the port over a channel so B knows where to connect.
+    let (port_tx, port_rx) = mpsc::channel::<u16>();
+    let dir_a_path = dir_a.path().to_path_buf();
+
+    let handle_a = std::thread::spawn(move || -> ZamResult<usize> {
+        let mut engine = ZamEngine::open_wal(dir_a_path, node_a, EventCounter::default())?;
+        let mut transport = TcpTransport::bind("127.0.0.1:0")?;
+        port_tx
+            .send(transport.local_addr()?.port())
+            .expect("port channel closed");
+        transport.accept_peer(node_b)?;
+        SyncSession::new(&mut engine, &mut transport).serve_one(node_b)?;
+        Ok(engine.state().count)
+    });
+
+    let port = port_rx.recv()?;
+
+    let mut engine_b = ZamEngine::open_wal(dir_b.path(), node_b, EventCounter::default())?;
+    let mut transport_b = TcpTransport::bind("127.0.0.1:0")?;
+    transport_b.connect(node_a, &format!("127.0.0.1:{}", port))?;
+
+    let stats_b = SyncSession::new(&mut engine_b, &mut transport_b).sync(node_a)?;
+
+    let count_a = handle_a.join().expect("thread A panicked")?;
+    let count_b = engine_b.state().count;
+
+    assert_eq!(count_a, 3, "A should have 3 events after sync");
+    assert_eq!(count_b, 3, "B should have 3 events after sync");
+    assert_eq!(
+        stats_b.events_received, 2,
+        "B should receive 2 events from A"
+    );
+    assert_eq!(stats_b.events_sent, 1, "B should send 1 event to A");
+
+    Ok(())
+}
+
+/// Syncing again after convergence transfers zero events.
+#[test]
+fn test_tcp_sync_idempotent() -> Result<(), Box<dyn std::error::Error>> {
+    let node_a = NodeId(10);
+    let node_b = NodeId(11);
+
+    let dir_a = tempdir()?;
+    let dir_b = tempdir()?;
+
+    // First sync
+    run_one_sync(&dir_a, node_a, &dir_b, node_b)?;
+
+    // Second sync -- nothing to transfer
+    let (sent, received) = run_one_sync(&dir_a, node_a, &dir_b, node_b)?;
+    assert_eq!(sent, 0, "no events should be sent on second sync");
+    assert_eq!(received, 0, "no events should be received on second sync");
+
+    Ok(())
+}
+
+fn run_one_sync(
+    dir_a: &tempfile::TempDir,
+    node_a: NodeId,
+    dir_b: &tempfile::TempDir,
+    node_b: NodeId,
+) -> ZamResult<(usize, usize)> {
+    let (port_tx, port_rx) = mpsc::channel::<u16>();
+    let dir_a_path = dir_a.path().to_path_buf();
+
+    let handle_a = std::thread::spawn(move || -> ZamResult<()> {
+        let mut engine = ZamEngine::open_wal(dir_a_path, node_a, EventCounter::default())?;
+        let mut transport = TcpTransport::bind("127.0.0.1:0")?;
+        port_tx
+            .send(transport.local_addr()?.port())
+            .expect("port channel closed");
+        transport.accept_peer(node_b)?;
+        SyncSession::new(&mut engine, &mut transport).serve_one(node_b)?;
+        Ok(())
+    });
+
+    let port = port_rx
+        .recv()
+        .map_err(|_| zamsync_core::ZamError::Protocol("port channel closed".into()))?;
+
+    let mut engine_b = ZamEngine::open_wal(dir_b.path(), node_b, EventCounter::default())?;
+    let mut transport_b = TcpTransport::bind("127.0.0.1:0")?;
+    transport_b.connect(node_a, &format!("127.0.0.1:{}", port))?;
+
+    let stats = SyncSession::new(&mut engine_b, &mut transport_b).sync(node_a)?;
+
+    handle_a.join().expect("thread A panicked")?;
+
+    Ok((stats.events_sent, stats.events_received))
+}

--- a/crates/zamsync-storage/src/engine.rs
+++ b/crates/zamsync-storage/src/engine.rs
@@ -1,4 +1,6 @@
 use crate::adapters::{FilePeerStore, WalEventStore};
+use crate::sorter::LogSorter;
+use std::collections::HashMap;
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 use zamsync_core::ports::{EventStore, PeerStore, StateStore};
@@ -139,6 +141,22 @@ impl<E: EventStore, P: PeerStore, S: StateStore> ZamEngine<E, P, S> {
 
     pub fn scan_events(&self) -> ZamResult<Box<dyn Iterator<Item = ZamResult<Event>>>> {
         self.event_store.scan()
+    }
+
+    /// Returns all events in deterministic global order (HLC, NodeId) via LogSorter.
+    /// This is the correct order for state projection when events from multiple nodes
+    /// are present in the WAL.
+    pub fn sorted_scan(&self) -> ZamResult<LogSorter<std::vec::IntoIter<ZamResult<Event>>>> {
+        let mut by_node: HashMap<u32, Vec<Event>> = HashMap::new();
+        for result in self.event_store.scan()? {
+            let event = result?;
+            by_node.entry(event.origin_node.0).or_default().push(event);
+        }
+        let iterators: Vec<_> = by_node
+            .into_values()
+            .map(|events| events.into_iter().map(Ok).collect::<Vec<_>>().into_iter())
+            .collect();
+        LogSorter::new(iterators)
     }
 
     pub fn state(&self) -> &S {

--- a/crates/zamsync-storage/src/sync_session.rs
+++ b/crates/zamsync-storage/src/sync_session.rs
@@ -31,9 +31,8 @@ where
         Self { engine, transport }
     }
 
-    /// Initiates a sync with `peer_id`: sends our handshake, processes the peer's
-    /// response (handshake + event batches + SyncComplete), then sends our own events
-    /// followed by SyncComplete.
+    /// Initiator side: sends our handshake, receives peer's handshake + events +
+    /// SyncComplete, then pushes our missing events and sends SyncComplete.
     pub fn sync(&mut self, peer_id: NodeId) -> ZamResult<SyncStats> {
         let mut stats = SyncStats::default();
 
@@ -42,17 +41,20 @@ where
 
         let peer_vv = self.wait_for_handshake(peer_id)?;
 
-        while let Some((from, msg)) = self.transport.receive()? {
-            if from != peer_id {
-                continue;
-            }
-            let is_complete = matches!(msg, SyncMessage::SyncComplete);
-            if let SyncMessage::EventBatch { ref events, .. } = msg {
-                stats.events_received += events.len();
-            }
-            self.engine.handle_sync_message(from, msg)?;
-            if is_complete {
-                break;
+        loop {
+            match self.transport.receive()? {
+                Some((from, msg)) if from == peer_id => {
+                    let is_complete = matches!(msg, SyncMessage::SyncComplete);
+                    if let SyncMessage::EventBatch { ref events, .. } = msg {
+                        stats.events_received += events.len();
+                    }
+                    self.engine.handle_sync_message(from, msg)?;
+                    if is_complete {
+                        break;
+                    }
+                }
+                Some(_) => continue,
+                None => continue,
             }
         }
 
@@ -72,6 +74,50 @@ where
             }
         }
         self.transport.send(peer_id, &SyncMessage::SyncComplete)?;
+
+        self.engine.sync()?;
+        Ok(stats)
+    }
+
+    /// Responder side: waits for the initiator's handshake, responds with our
+    /// handshake + events + SyncComplete, then receives initiator's events until
+    /// their SyncComplete.
+    pub fn serve_one(&mut self, peer_id: NodeId) -> ZamResult<SyncStats> {
+        let mut stats = SyncStats::default();
+
+        // Phase 1: wait for initiator's Handshake, respond immediately
+        loop {
+            match self.transport.receive()? {
+                Some((from, msg @ SyncMessage::Handshake { .. })) if from == peer_id => {
+                    let responses = self.engine.handle_sync_message(from, msg)?;
+                    for response in &responses {
+                        if let SyncMessage::EventBatch { events, .. } = response {
+                            stats.events_sent += events.len();
+                        }
+                        self.transport.send(peer_id, response)?;
+                    }
+                    break;
+                }
+                Some(_) | None => continue,
+            }
+        }
+
+        // Phase 2: receive initiator's events until their SyncComplete
+        loop {
+            match self.transport.receive()? {
+                Some((from, msg)) if from == peer_id => {
+                    let is_complete = matches!(msg, SyncMessage::SyncComplete);
+                    if let SyncMessage::EventBatch { ref events, .. } = msg {
+                        stats.events_received += events.len();
+                    }
+                    self.engine.handle_sync_message(from, msg)?;
+                    if is_complete {
+                        break;
+                    }
+                }
+                Some(_) | None => continue,
+            }
+        }
 
         self.engine.sync()?;
         Ok(stats)

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,8 @@ use std::env;
 use std::path::PathBuf;
 use zamsync_core::ports::StateStore;
 use zamsync_core::{Event, NodeId, SequenceNumber, ZamResult};
-use zamsync_storage::ZamEngine;
+use zamsync_network::TcpTransport;
+use zamsync_storage::{SyncSession, ZamEngine};
 
 #[derive(Default)]
 struct EventCounter {
@@ -24,56 +25,102 @@ impl StateStore for EventCounter {
 fn usage() {
     eprintln!(
         "Usage:
-  zamsync info <data-dir>          Show node status
-  zamsync submit <data-dir> <msg>  Append an event with a text payload"
+  zamsync info   <data-dir>
+  zamsync submit <data-dir> <payload>
+  zamsync sync   <data-dir> <peer-addr> <peer-id>
+  zamsync serve  <data-dir> <bind-addr> <peer-id>"
     );
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
     let args: Vec<String> = env::args().collect();
 
     match args.get(1).map(String::as_str) {
-        Some("info") => {
-            let dir = data_dir(&args, 2)?;
-            let node_id = node_id_from_dir(&dir);
-            let engine = ZamEngine::open_wal(&dir, node_id, EventCounter::default())?;
-
-            println!("node_id  : {}", node_id.0);
-            println!("data_dir : {}", dir.display());
-            println!("events   : {}", engine.state().count);
-            let vv = &engine.replication_state().local_vv;
-            if vv.entries.is_empty() {
-                println!("vv       : (empty)");
-            } else {
-                for (node, seq) in &vv.entries {
-                    println!("vv       : node {} @ seq {}", node, seq.0);
-                }
-            }
-        }
-        Some("submit") => {
-            let dir = data_dir(&args, 2)?;
-            let payload = args
-                .get(3)
-                .ok_or("missing payload argument")?
-                .as_bytes()
-                .to_vec();
-            let node_id = node_id_from_dir(&dir);
-            let mut engine = ZamEngine::open_wal(&dir, node_id, EventCounter::default())?;
-            let seq = engine.submit(1, payload)?;
-            engine.sync()?;
-            println!("submitted seq={}", seq.0);
-        }
+        Some("info") => cmd_info(&args),
+        Some("submit") => cmd_submit(&args),
+        Some("sync") => cmd_sync(&args),
+        Some("serve") => cmd_serve(&args),
         _ => {
             usage();
             std::process::exit(1);
         }
     }
+}
 
+fn cmd_info(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
+    let dir = data_dir(args, 2)?;
+    let node_id = node_id_from_dir(&dir);
+    let engine = ZamEngine::open_wal(&dir, node_id, EventCounter::default())?;
+
+    println!("node_id  : {}", node_id.0);
+    println!("data_dir : {}", dir.display());
+    println!("events   : {}", engine.state().count);
+    let vv = &engine.replication_state().local_vv;
+    if vv.entries.is_empty() {
+        println!("vv       : (empty)");
+    } else {
+        for (node, seq) in &vv.entries {
+            println!("vv       : node {} @ seq {}", node, seq.0);
+        }
+    }
+    Ok(())
+}
+
+fn cmd_submit(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
+    let dir = data_dir(args, 2)?;
+    let payload = args.get(3).ok_or("missing payload")?.as_bytes().to_vec();
+    let node_id = node_id_from_dir(&dir);
+    let mut engine = ZamEngine::open_wal(&dir, node_id, EventCounter::default())?;
+    let seq = engine.submit(1, payload)?;
+    engine.sync()?;
+    println!("submitted seq={}", seq.0);
+    Ok(())
+}
+
+fn cmd_sync(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
+    let dir = data_dir(args, 2)?;
+    let peer_addr = args.get(3).ok_or("missing peer-addr")?;
+    let peer_id: u32 = args.get(4).ok_or("missing peer-id")?.parse()?;
+
+    let node_id = node_id_from_dir(&dir);
+    let mut engine = ZamEngine::open_wal(&dir, node_id, EventCounter::default())?;
+
+    let mut transport = TcpTransport::bind("0.0.0.0:0")?;
+    transport.connect(NodeId(peer_id), peer_addr)?;
+
+    let stats = SyncSession::new(&mut engine, &mut transport).sync(NodeId(peer_id))?;
+    println!(
+        "sync done: sent={} received={}",
+        stats.events_sent, stats.events_received
+    );
+    Ok(())
+}
+
+fn cmd_serve(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
+    let dir = data_dir(args, 2)?;
+    let bind_addr = args.get(3).ok_or("missing bind-addr")?;
+    let peer_id: u32 = args.get(4).ok_or("missing peer-id")?.parse()?;
+
+    let node_id = node_id_from_dir(&dir);
+    let mut engine = ZamEngine::open_wal(&dir, node_id, EventCounter::default())?;
+
+    let mut transport = TcpTransport::bind(bind_addr)?;
+    println!("listening on {}", transport.local_addr()?);
+    println!("waiting for peer {}...", peer_id);
+
+    transport.accept_peer(NodeId(peer_id))?;
+
+    let stats = SyncSession::new(&mut engine, &mut transport).serve_one(NodeId(peer_id))?;
+    println!(
+        "sync done: sent={} received={}",
+        stats.events_sent, stats.events_received
+    );
     Ok(())
 }
 
 fn data_dir(args: &[String], pos: usize) -> Result<PathBuf, Box<dyn std::error::Error>> {
-    let path = PathBuf::from(args.get(pos).ok_or("missing data-dir argument")?);
+    let path = PathBuf::from(args.get(pos).ok_or("missing data-dir")?);
     std::fs::create_dir_all(&path)?;
     Ok(path)
 }
@@ -87,7 +134,7 @@ fn node_id_from_dir(dir: &std::path::Path) -> NodeId {
             }
         }
     }
-    let id: u32 = rand_u32();
+    let id = rand_u32();
     let _ = std::fs::write(&id_file, id.to_string());
     NodeId(id)
 }


### PR DESCRIPTION
## Summary

- **TcpTransport fixed**: removed the dropped-incoming-stream bug; added `accept_peer(peer_id)` (blocking accept, registers under known NodeId) and `local_addr()` for port discovery
- **`SyncSession::serve_one`**: responder-side counterpart to `sync()`. Waits for initiator's Handshake, responds immediately with our Handshake + EventBatches + SyncComplete, then receives the initiator's events. Closes the full bidirectional protocol loop.
- **`ZamEngine::sorted_scan`**: partitions WAL events by origin_node and feeds them to LogSorter. Exposes the deterministic HLC-ordered global replay guaranteed by G2. Previously the LogSorter existed but was not reachable through the engine API.
- **CLI extended**: `sync <data-dir> <peer-addr> <peer-id>` (initiator) and `serve <data-dir> <bind-addr> <peer-id>` (responder). Two nodes can now sync with a single command pair.
- **TCP integration tests**: `test_tcp_sync_end_to_end` (2 nodes, loopback socket, 3 events total, full convergence asserted) and `test_tcp_sync_idempotent` (second sync transfers zero events).
- **ROADMAP updated**: reflects current state across 3 completed phases, and outlines Phase 4 (hardening) and beyond.

## Protocol flow (implemented and tested)

```
Initiator (B)              Responder (A)
  sync()                     serve_one()
    |-- Handshake(B) -------->|
    |<-- Handshake(A) --------|
    |<-- EventBatch(A events)-|
    |<-- SyncComplete --------|
    |-- EventBatch(B events)->|
    |-- SyncComplete -------->|
```

## Test plan

- [ ] CI passes (fmt + clippy -D warnings + test --workspace)
- [ ] `test_tcp_sync_end_to_end`: A has 2 events, B has 1 event, after sync both have 3
- [ ] `test_tcp_sync_idempotent`: second sync sends/receives 0 events
- [ ] All 21 workspace tests green
