### PR TITLE
feat: hardening -- crash recovery fix, serve loop, tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,56 +23,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,41 +93,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "colorchoice"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
-
-[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "env_filter"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
 ]
 
 [[package]]
@@ -311,40 +232,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "jiff"
-version = "0.2.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "js-sys"
@@ -357,6 +248,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -383,10 +280,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "once_cell"
@@ -395,31 +310,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "once_cell_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "prettyplease"
@@ -480,18 +374,6 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
-name = "regex"
-version = "1.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
 
 [[package]]
 name = "regex-automata"
@@ -623,6 +505,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -633,6 +524,12 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "syn"
@@ -696,6 +593,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,6 +617,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,12 +690,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
 name = "uuid"
 version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,6 +698,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
@@ -969,8 +936,9 @@ dependencies = [
 name = "zamsync"
 version = "0.1.0"
 dependencies = [
- "env_logger",
  "log",
+ "tracing",
+ "tracing-subscriber",
  "zamsync-core",
  "zamsync-network",
  "zamsync-storage",
@@ -994,6 +962,7 @@ dependencies = [
  "log",
  "rkyv",
  "tempfile",
+ "tracing",
  "zamsync-core",
  "zamsync-storage",
 ]
@@ -1009,6 +978,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "tracing",
  "zamsync-core",
  "zamsync-testing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,8 @@ zamsync-storage = { path = "crates/zamsync-storage" }
 zamsync-network = { path = "crates/zamsync-network" }
 zamsync-core = { path = "crates/zamsync-core" }
 log.workspace = true
-env_logger = "0.11"
+tracing.workspace = true
+tracing-subscriber.workspace = true
 
 [workspace.dependencies]
 serde = { version = "1.0", features = ["derive"] }
@@ -40,3 +41,5 @@ bytecheck = "0.6"
 crc32fast = "1.4"
 byteorder = "1.5"
 tempfile = "3.10"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/zamsync-network/Cargo.toml
+++ b/crates/zamsync-network/Cargo.toml
@@ -11,6 +11,7 @@ zamsync-core = { path = "../zamsync-core" }
 rkyv.workspace = true
 byteorder.workspace = true
 log.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 zamsync-storage = { path = "../zamsync-storage" }

--- a/crates/zamsync-network/src/transport/tcp.rs
+++ b/crates/zamsync-network/src/transport/tcp.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::io::BufWriter;
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::time::Duration;
+use tracing::{info, warn};
 use zamsync_core::ports::Transport;
 use zamsync_core::{NodeId, SyncMessage, ZamError, ZamResult};
 
@@ -21,7 +22,7 @@ impl TcpTransport {
     pub fn bind(addr: &str) -> ZamResult<Self> {
         let listener = TcpListener::bind(addr)?;
         listener.set_nonblocking(true)?;
-        log::info!("listening on {}", addr);
+        info!("listening on {}", addr);
         Ok(Self {
             listener,
             peers: HashMap::new(),
@@ -45,7 +46,7 @@ impl TcpTransport {
                 pending: None,
             },
         );
-        log::info!("accepted peer {} from {}", peer_id.0, addr);
+        info!(peer = peer_id.0, %addr, "accepted peer");
         Ok(())
     }
 
@@ -61,10 +62,14 @@ impl TcpTransport {
         let msg = protocol::decode(&mut stream)?;
         let node_id = match &msg {
             SyncMessage::Handshake { node_id, .. } => *node_id,
-            _ => {
+            other => {
+                warn!(
+                    ?other,
+                    "expected Handshake as first message, closing connection"
+                );
                 return Err(ZamError::Protocol(
                     "first message from peer must be a Handshake".into(),
-                ))
+                ));
             }
         };
 
@@ -76,7 +81,7 @@ impl TcpTransport {
                 pending: Some(msg),
             },
         );
-        log::info!("accepted peer {} from {}", node_id.0, addr);
+        info!(peer = node_id.0, %addr, "accepted peer via Handshake");
         Ok(node_id)
     }
 
@@ -95,7 +100,7 @@ impl TcpTransport {
                 pending: None,
             },
         );
-        log::info!("connected to peer {} at {}", peer_id.0, addr);
+        info!(peer = peer_id.0, addr, "connected to peer");
         Ok(())
     }
 

--- a/crates/zamsync-network/src/transport/tcp.rs
+++ b/crates/zamsync-network/src/transport/tcp.rs
@@ -6,9 +6,15 @@ use std::time::Duration;
 use zamsync_core::ports::Transport;
 use zamsync_core::{NodeId, SyncMessage, ZamError, ZamResult};
 
+struct PeerConn {
+    stream: TcpStream,
+    /// One message read ahead (e.g. Handshake consumed during accept_any).
+    pending: Option<SyncMessage>,
+}
+
 pub struct TcpTransport {
     listener: TcpListener,
-    peers: HashMap<u32, TcpStream>,
+    peers: HashMap<u32, PeerConn>,
 }
 
 impl TcpTransport {
@@ -22,7 +28,6 @@ impl TcpTransport {
         })
     }
 
-    /// Returns the local address the listener is bound to.
     pub fn local_addr(&self) -> ZamResult<SocketAddr> {
         Ok(self.listener.local_addr()?)
     }
@@ -33,15 +38,63 @@ impl TcpTransport {
         let (stream, addr) = self.listener.accept()?;
         self.listener.set_nonblocking(true)?;
         stream.set_read_timeout(Some(Duration::from_millis(50)))?;
-        self.peers.insert(peer_id.0, stream);
+        self.peers.insert(
+            peer_id.0,
+            PeerConn {
+                stream,
+                pending: None,
+            },
+        );
         log::info!("accepted peer {} from {}", peer_id.0, addr);
         Ok(())
+    }
+
+    /// Blocking accept: reads the first Handshake to discover the peer's NodeId.
+    /// The Handshake is buffered and will be returned by the next `receive()` call.
+    /// Returns the peer's NodeId so callers can pass it to `serve_one`.
+    pub fn accept_any(&mut self) -> ZamResult<NodeId> {
+        self.listener.set_nonblocking(false)?;
+        let (mut stream, addr) = self.listener.accept()?;
+        self.listener.set_nonblocking(true)?;
+        stream.set_read_timeout(Some(Duration::from_millis(5_000)))?;
+
+        let msg = protocol::decode(&mut stream)?;
+        let node_id = match &msg {
+            SyncMessage::Handshake { node_id, .. } => *node_id,
+            _ => {
+                return Err(ZamError::Protocol(
+                    "first message from peer must be a Handshake".into(),
+                ))
+            }
+        };
+
+        stream.set_read_timeout(Some(Duration::from_millis(50)))?;
+        self.peers.insert(
+            node_id.0,
+            PeerConn {
+                stream,
+                pending: Some(msg),
+            },
+        );
+        log::info!("accepted peer {} from {}", node_id.0, addr);
+        Ok(node_id)
+    }
+
+    /// Removes a peer connection, allowing the slot to be reused.
+    pub fn disconnect(&mut self, peer_id: NodeId) {
+        self.peers.remove(&peer_id.0);
     }
 
     pub fn connect(&mut self, peer_id: NodeId, addr: &str) -> ZamResult<()> {
         let stream = TcpStream::connect(addr)?;
         stream.set_read_timeout(Some(Duration::from_millis(50)))?;
-        self.peers.insert(peer_id.0, stream);
+        self.peers.insert(
+            peer_id.0,
+            PeerConn {
+                stream,
+                pending: None,
+            },
+        );
         log::info!("connected to peer {} at {}", peer_id.0, addr);
         Ok(())
     }
@@ -53,19 +106,22 @@ impl TcpTransport {
 
 impl Transport for TcpTransport {
     fn send(&mut self, peer_id: NodeId, message: &SyncMessage) -> ZamResult<()> {
-        let stream = self
+        let peer = self
             .peers
             .get_mut(&peer_id.0)
             .ok_or_else(|| ZamError::Protocol(format!("no connection to peer {}", peer_id.0)))?;
-        let mut writer = BufWriter::new(stream as &TcpStream);
+        let mut writer = BufWriter::new(&peer.stream);
         protocol::encode(message, &mut writer)
     }
 
     fn receive(&mut self) -> ZamResult<Option<(NodeId, SyncMessage)>> {
         let peer_ids: Vec<u32> = self.peers.keys().cloned().collect();
         for peer_id_raw in peer_ids {
-            if let Some(stream) = self.peers.get_mut(&peer_id_raw) {
-                match protocol::decode(stream) {
+            if let Some(peer) = self.peers.get_mut(&peer_id_raw) {
+                if let Some(msg) = peer.pending.take() {
+                    return Ok(Some((NodeId(peer_id_raw), msg)));
+                }
+                match protocol::decode(&mut peer.stream) {
                     Ok(msg) => return Ok(Some((NodeId(peer_id_raw), msg))),
                     Err(ZamError::Io(e))
                         if e.kind() == std::io::ErrorKind::WouldBlock

--- a/crates/zamsync-storage/Cargo.toml
+++ b/crates/zamsync-storage/Cargo.toml
@@ -12,6 +12,7 @@ crc32fast.workspace = true
 byteorder.workspace = true
 log.workspace = true
 rkyv.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/zamsync-storage/src/engine.rs
+++ b/crates/zamsync-storage/src/engine.rs
@@ -4,7 +4,9 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 use zamsync_core::ports::{EventStore, PeerStore, StateStore};
-use zamsync_core::{Event, Hlc, NodeId, ReplicationState, SequenceNumber, SyncMessage, ZamResult};
+use zamsync_core::{
+    Event, Hlc, NodeId, ReplicationState, SequenceNumber, SyncMessage, VersionVector, ZamResult,
+};
 
 pub struct ZamEngine<E: EventStore, P: PeerStore, S: StateStore> {
     node_id: NodeId,
@@ -18,16 +20,23 @@ pub struct ZamEngine<E: EventStore, P: PeerStore, S: StateStore> {
 impl<E: EventStore, P: PeerStore, S: StateStore> ZamEngine<E, P, S> {
     pub fn new(node_id: NodeId, event_store: E, peer_store: P, mut state: S) -> ZamResult<Self> {
         let mut max_hlc = Hlc::default();
+        let mut wal_vv = VersionVector::default();
 
         for event_res in event_store.scan()? {
             let event = event_res?;
             if event.hlc > max_hlc {
                 max_hlc = event.hlc;
             }
+            // Rebuild VV from WAL: the WAL is the authoritative source of truth.
+            // A crash can leave peers.state ahead of the WAL, which would corrupt
+            // the VV and cause events to be considered "already seen" when they are not.
+            wal_vv.update(event.origin_node, event.seq);
             state.apply_event(event.seq, &event)?;
         }
 
-        let replication = peer_store.load()?;
+        let mut replication = peer_store.load()?;
+        // Override local_vv with the WAL-derived VV. Peer knowledge entries are kept.
+        replication.local_vv = wal_vv;
 
         Ok(Self {
             node_id,

--- a/crates/zamsync-storage/src/sync_session.rs
+++ b/crates/zamsync-storage/src/sync_session.rs
@@ -1,3 +1,4 @@
+use tracing::{instrument, warn};
 use zamsync_core::ports::{EventStore, PeerStore, StateStore, Transport};
 use zamsync_core::{NodeId, SyncMessage, ZamError, ZamResult};
 
@@ -33,6 +34,7 @@ where
 
     /// Initiator side: sends our handshake, receives peer's handshake + events +
     /// SyncComplete, then pushes our missing events and sends SyncComplete.
+    #[instrument(skip(self), fields(peer = peer_id.0))]
     pub fn sync(&mut self, peer_id: NodeId) -> ZamResult<SyncStats> {
         let mut stats = SyncStats::default();
 
@@ -75,6 +77,12 @@ where
         }
         self.transport.send(peer_id, &SyncMessage::SyncComplete)?;
 
+        tracing::info!(
+            peer = peer_id.0,
+            sent = stats.events_sent,
+            received = stats.events_received,
+            "sync complete"
+        );
         self.engine.sync()?;
         Ok(stats)
     }
@@ -82,6 +90,7 @@ where
     /// Responder side: waits for the initiator's handshake, responds with our
     /// handshake + events + SyncComplete, then receives initiator's events until
     /// their SyncComplete.
+    #[instrument(skip(self), fields(peer = peer_id.0))]
     pub fn serve_one(&mut self, peer_id: NodeId) -> ZamResult<SyncStats> {
         let mut stats = SyncStats::default();
 
@@ -119,6 +128,12 @@ where
             }
         }
 
+        tracing::info!(
+            peer = peer_id.0,
+            sent = stats.events_sent,
+            received = stats.events_received,
+            "serve_one complete"
+        );
         self.engine.sync()?;
         Ok(stats)
     }
@@ -135,6 +150,7 @@ where
                 Some(_) | None => continue,
             }
         }
+        warn!(peer = expected_peer.0, "timeout waiting for peer handshake");
         Err(ZamError::Protocol(
             "timeout waiting for peer handshake".into(),
         ))

--- a/crates/zamsync-storage/src/wal.rs
+++ b/crates/zamsync-storage/src/wal.rs
@@ -3,6 +3,7 @@ use crc32fast::Hasher;
 use std::fs::{File, OpenOptions};
 use std::io::{self, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::Path;
+use tracing::warn;
 use zamsync_core::{SequenceNumber, ZamError, ZamResult, WAL_MAGIC, WAL_VERSION};
 
 /// WAL Header Size: 4 (Magic) + 1 (Ver) + 4 (CRC) + 8 (Seq) + 4 (Len) = 21 bytes.
@@ -106,7 +107,7 @@ impl WalScanner {
                 }
                 None => break,
                 Some(Err(e)) => {
-                    log::warn!("WAL recovery stopped at pos {}: {}", it.offset, e);
+                    warn!(pos = it.offset, error = %e, "WAL recovery stopped");
                     break;
                 }
             }

--- a/crates/zamsync-storage/tests/crash_test.rs
+++ b/crates/zamsync-storage/tests/crash_test.rs
@@ -1,0 +1,234 @@
+use std::fs::OpenOptions;
+use std::io::{Seek, SeekFrom, Write};
+use tempfile::tempdir;
+use zamsync_core::ports::StateStore;
+use zamsync_core::{Event, NodeId, SequenceNumber, ZamResult};
+use zamsync_storage::wal::{WalScanner, WalWriter, WAL_HEADER_SIZE};
+use zamsync_storage::{FilePeerStore, WalEventStore, ZamEngine};
+
+#[derive(Default)]
+struct Counter(usize);
+
+impl StateStore for Counter {
+    fn apply_event(&mut self, _seq: SequenceNumber, _event: &Event) -> ZamResult<()> {
+        self.0 += 1;
+        Ok(())
+    }
+    fn last_applied_seq(&self) -> Option<SequenceNumber> {
+        None
+    }
+}
+
+fn open_engine(
+    dir: &tempfile::TempDir,
+    node: NodeId,
+) -> ZamResult<ZamEngine<WalEventStore, FilePeerStore, Counter>> {
+    ZamEngine::open_wal(dir.path(), node, Counter::default())
+}
+
+// ---------------------------------------------------------------------------
+// WAL-level crash scenarios (use WalWriter directly -- known payload sizes)
+// ---------------------------------------------------------------------------
+
+/// Truncating a single byte from the payload stops recovery before that record.
+#[test]
+fn test_wal_truncate_mid_payload() -> ZamResult<()> {
+    let dir = tempdir()?;
+    let path = dir.path().join("test.wal");
+
+    let mut w = WalWriter::open(&path, SequenceNumber::ZERO)?;
+    w.append(b"first")?;
+    w.append(b"second")?;
+    w.sync()?;
+
+    // Cut one byte off the end (inside the second record's payload)
+    let len = std::fs::metadata(&path)?.len();
+    OpenOptions::new()
+        .write(true)
+        .open(&path)?
+        .set_len(len - 1)?;
+
+    let (last_seq, _) = WalScanner::recover(&path)?;
+    assert_eq!(
+        last_seq,
+        Some(SequenceNumber(0)),
+        "only first record survives"
+    );
+
+    Ok(())
+}
+
+/// Truncating to exactly after the first record leaves it intact.
+#[test]
+fn test_wal_truncate_after_first_record() -> ZamResult<()> {
+    let dir = tempdir()?;
+    let path = dir.path().join("test.wal");
+
+    let payload = b"keep";
+    let mut w = WalWriter::open(&path, SequenceNumber::ZERO)?;
+    w.append(payload)?;
+    w.append(b"drop")?;
+    w.sync()?;
+
+    let first_size = (WAL_HEADER_SIZE + payload.len()) as u64;
+    OpenOptions::new()
+        .write(true)
+        .open(&path)?
+        .set_len(first_size)?;
+
+    let (last_seq, pos) = WalScanner::recover(&path)?;
+    assert_eq!(last_seq, Some(SequenceNumber(0)));
+    assert_eq!(pos, first_size);
+
+    Ok(())
+}
+
+/// Corrupting the CRC of the second record makes recovery stop after the first.
+#[test]
+fn test_wal_corrupt_crc_stops_recovery() -> ZamResult<()> {
+    let dir = tempdir()?;
+    let path = dir.path().join("test.wal");
+
+    let first_payload = b"ok";
+    let mut w = WalWriter::open(&path, SequenceNumber::ZERO)?;
+    w.append(first_payload)?;
+    w.append(b"bad")?;
+    w.sync()?;
+
+    // Flip a byte inside the second record's payload
+    let second_record_start = WAL_HEADER_SIZE + first_payload.len();
+    let corrupt_offset = (second_record_start + WAL_HEADER_SIZE + 1) as u64;
+    {
+        let mut f = OpenOptions::new().write(true).open(&path)?;
+        f.seek(SeekFrom::Start(corrupt_offset))?;
+        f.write_all(&[0xff])?;
+    }
+
+    let (last_seq, _) = WalScanner::recover(&path)?;
+    assert_eq!(last_seq, Some(SequenceNumber(0)));
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Engine-level crash scenarios
+// ---------------------------------------------------------------------------
+
+/// Snapshot WAL size after first event, write a second, truncate back.
+/// Engine must recover only the first event.
+#[test]
+fn test_engine_recovers_after_wal_truncation() -> ZamResult<()> {
+    let dir = tempdir()?;
+    let wal_path = dir.path().join("events.wal");
+    let node = NodeId(1);
+
+    // Write first event and snapshot WAL size
+    let size_after_first = {
+        let mut e = open_engine(&dir, node)?;
+        e.submit(1, b"A".to_vec())?;
+        e.sync()?;
+        std::fs::metadata(&wal_path)?.len()
+    };
+
+    // Write second and third events
+    {
+        let mut e = open_engine(&dir, node)?;
+        e.submit(1, b"B".to_vec())?;
+        e.submit(1, b"C".to_vec())?;
+        e.sync()?;
+    }
+
+    // Truncate to just after the first event (simulates crash mid-write of B)
+    OpenOptions::new()
+        .write(true)
+        .open(&wal_path)?
+        .set_len(size_after_first)?;
+
+    let mut recovered = open_engine(&dir, node)?;
+    assert_eq!(recovered.state().0, 1, "only 1 event should survive");
+
+    // Next submit must continue at seq 1, not seq 2 or 3
+    let seq = recovered.submit(1, b"D".to_vec())?;
+    assert_eq!(seq, SequenceNumber(1), "next seq must be 1 after recovery");
+
+    Ok(())
+}
+
+/// VV rebuilt from WAL must reflect only the events that survived truncation.
+#[test]
+fn test_engine_vv_consistent_after_recovery() -> ZamResult<()> {
+    let dir = tempdir()?;
+    let wal_path = dir.path().join("events.wal");
+    let node = NodeId(1);
+
+    // Write first event and snapshot WAL size
+    let size_after_first = {
+        let mut e = open_engine(&dir, node)?;
+        e.submit(1, b"x".to_vec())?;
+        e.sync()?;
+        std::fs::metadata(&wal_path)?.len()
+    };
+
+    // Write second event
+    {
+        let mut e = open_engine(&dir, node)?;
+        e.submit(1, b"y".to_vec())?;
+        e.sync()?;
+    }
+
+    // Truncate back to just after first event
+    OpenOptions::new()
+        .write(true)
+        .open(&wal_path)?
+        .set_len(size_after_first)?;
+
+    let recovered = open_engine(&dir, node)?;
+    let vv = &recovered.replication_state().local_vv;
+    assert_eq!(
+        vv.entries.get(&node.0),
+        Some(&SequenceNumber(0)),
+        "VV must reflect only seq 0 (x), not seq 1 (y)"
+    );
+
+    Ok(())
+}
+
+/// After recovery, submitting new events continues correctly and a fresh
+/// engine can replay them all without errors.
+#[test]
+fn test_engine_append_after_recovery() -> ZamResult<()> {
+    let dir = tempdir()?;
+    let wal_path = dir.path().join("events.wal");
+    let node = NodeId(1);
+
+    let size_after_first = {
+        let mut e = open_engine(&dir, node)?;
+        e.submit(1, b"durable".to_vec())?;
+        e.sync()?;
+        std::fs::metadata(&wal_path)?.len()
+    };
+
+    // Simulate crash after partial second write
+    {
+        let mut e = open_engine(&dir, node)?;
+        e.submit(1, b"lost".to_vec())?;
+        // no sync -- also truncate to be sure
+    }
+    OpenOptions::new()
+        .write(true)
+        .open(&wal_path)?
+        .set_len(size_after_first)?;
+
+    // Recover and append a new event
+    {
+        let mut e = open_engine(&dir, node)?;
+        e.submit(1, b"new".to_vec())?;
+        e.sync()?;
+    }
+
+    // Re-open and verify exactly 2 events: "durable" and "new"
+    let final_engine = open_engine(&dir, node)?;
+    assert_eq!(final_engine.state().0, 2, "should have exactly 2 events");
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use std::env;
 use std::path::PathBuf;
+use tracing_subscriber::EnvFilter;
 use zamsync_core::ports::StateStore;
 use zamsync_core::{Event, NodeId, SequenceNumber, ZamResult};
 use zamsync_network::TcpTransport;
@@ -33,7 +34,9 @@ fn usage() {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    env_logger::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
     let args: Vec<String> = env::args().collect();
 
     match args.get(1).map(String::as_str) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ fn usage() {
   zamsync info   <data-dir>
   zamsync submit <data-dir> <payload>
   zamsync sync   <data-dir> <peer-addr> <peer-id>
-  zamsync serve  <data-dir> <bind-addr> <peer-id>"
+  zamsync serve  <data-dir> <bind-addr>"
     );
 }
 
@@ -100,23 +100,29 @@ fn cmd_sync(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
 fn cmd_serve(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     let dir = data_dir(args, 2)?;
     let bind_addr = args.get(3).ok_or("missing bind-addr")?;
-    let peer_id: u32 = args.get(4).ok_or("missing peer-id")?.parse()?;
 
     let node_id = node_id_from_dir(&dir);
-    let mut engine = ZamEngine::open_wal(&dir, node_id, EventCounter::default())?;
-
     let mut transport = TcpTransport::bind(bind_addr)?;
-    println!("listening on {}", transport.local_addr()?);
-    println!("waiting for peer {}...", peer_id);
-
-    transport.accept_peer(NodeId(peer_id))?;
-
-    let stats = SyncSession::new(&mut engine, &mut transport).serve_one(NodeId(peer_id))?;
     println!(
-        "sync done: sent={} received={}",
-        stats.events_sent, stats.events_received
+        "node {} listening on {}",
+        node_id.0,
+        transport.local_addr()?
     );
-    Ok(())
+
+    loop {
+        println!("waiting for peer...");
+        let mut engine = ZamEngine::open_wal(&dir, node_id, EventCounter::default())?;
+
+        let peer_id = transport.accept_any()?;
+        println!("peer {} connected", peer_id.0);
+
+        let stats = SyncSession::new(&mut engine, &mut transport).serve_one(peer_id)?;
+        println!(
+            "sync with peer {} done: sent={} received={}",
+            peer_id.0, stats.events_sent, stats.events_received
+        );
+        transport.disconnect(peer_id);
+    }
 }
 
 fn data_dir(args: &[String], pos: usize) -> Result<PathBuf, Box<dyn std::error::Error>> {


### PR DESCRIPTION
## Summary

- **Bug fix (engine recovery)**: `ZamEngine::new` now rebuilds `local_vv` from the WAL instead of loading it from `peers.state`. A crash could leave `peers.state` ahead of the WAL, causing events to be considered already seen when they were not. The WAL is the authoritative source of truth for the local version vector.

- **Crash-consistency test suite** (6 tests): WAL truncation mid-payload, truncation after first record, CRC corruption stops recovery, engine sees only surviving events, VV is consistent after truncation, append continues correctly after recovery.

- **Continuous serve loop**: `TcpTransport` gains `accept_any()` which does a blocking accept, reads the first Handshake, extracts the peer NodeId from it, and buffers the Handshake for the next `receive()` call. `cmd_serve` becomes an infinite loop: accept a peer, sync, disconnect, repeat -- no `--peer-id` argument needed.

- **Tracing**: replaced all `log::` calls with `tracing` spans and structured fields (`peer`, `sent`, `received`, `error`). `SyncSession::sync` and `serve_one` are both instrumented with `#[instrument]`. The CLI initialises `tracing_subscriber` with `RUST_LOG` env-filter support.

## Test plan

- [ ] CI passes (fmt + clippy -D warnings + test --workspace)
- [ ] 27 workspace tests all green
- [ ] `test_engine_recovers_after_wal_truncation`: only 1 event survives, next seq is 1
- [ ] `test_engine_vv_consistent_after_recovery`: VV reflects only the WAL, not the peer store
- [ ] `test_engine_append_after_recovery`: 2 events after recover + append
- [ ] `RUST_LOG=info zamsync serve ./data 0.0.0.0:7000` shows structured tracing output