### PR TITLE
feat: Phase 5 performance -- chunked batches, WAL compaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,56 +23,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,41 +93,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "colorchoice"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
-
-[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "env_filter"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
 ]
 
 [[package]]
@@ -311,40 +232,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "jiff"
-version = "0.2.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "js-sys"
@@ -357,6 +248,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -383,10 +280,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "once_cell"
@@ -395,31 +310,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "once_cell_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "prettyplease"
@@ -480,18 +374,6 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
-name = "regex"
-version = "1.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
 
 [[package]]
 name = "regex-automata"
@@ -623,6 +505,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -633,6 +524,12 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "syn"
@@ -696,6 +593,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,6 +617,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,12 +690,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
 name = "uuid"
 version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,6 +698,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
@@ -969,8 +936,9 @@ dependencies = [
 name = "zamsync"
 version = "0.1.0"
 dependencies = [
- "env_logger",
  "log",
+ "tracing",
+ "tracing-subscriber",
  "zamsync-core",
  "zamsync-network",
  "zamsync-storage",
@@ -994,6 +962,7 @@ dependencies = [
  "log",
  "rkyv",
  "tempfile",
+ "tracing",
  "zamsync-core",
  "zamsync-storage",
 ]
@@ -1009,6 +978,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "tracing",
  "zamsync-core",
  "zamsync-testing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,8 @@ zamsync-storage = { path = "crates/zamsync-storage" }
 zamsync-network = { path = "crates/zamsync-network" }
 zamsync-core = { path = "crates/zamsync-core" }
 log.workspace = true
-env_logger = "0.11"
+tracing.workspace = true
+tracing-subscriber.workspace = true
 
 [workspace.dependencies]
 serde = { version = "1.0", features = ["derive"] }
@@ -40,3 +41,5 @@ bytecheck = "0.6"
 crc32fast = "1.4"
 byteorder = "1.5"
 tempfile = "3.10"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ ZamSync uses **hexagonal architecture** (ports and adapters). The sync core is a
 
 ```
 zamsync-core        -- Event, HLC, VersionVector, SyncMessage, port traits
-zamsync-storage     -- WAL event store, file peer store, ZamEngine
+zamsync-storage     -- WAL event store, file peer store, ZamEngine, SyncSession
 zamsync-network     -- TCP transport, binary wire protocol
 zamsync-testing     -- In-memory adapters, MockTransport, run_direct_sync
-zamsync (binary)    -- CLI: info, submit
+zamsync (binary)    -- CLI: info, submit, sync, serve
 ```
 
 ### Port Traits
@@ -59,13 +59,12 @@ The engine `ZamEngine<E: EventStore, P: PeerStore, S: StateStore>` is generic ov
 
 ### Sync Protocol
 
-Peers exchange `SyncMessage` frames. A session:
+Peers exchange `SyncMessage` frames over TCP. Roles are asymmetric:
 
-1. Both sides send a `Handshake` carrying their Version Vector.
-2. Each side computes gaps and pushes missing `EventBatch` messages.
-3. Each side sends `SyncComplete` when done.
+- **Initiator** (`sync`): connects to peer, sends Handshake, receives peer's events, pushes own missing events, sends SyncComplete.
+- **Responder** (`serve`): accepts connection, receives Handshake, immediately pushes all missing events + SyncComplete, then waits for initiator's events.
 
-Events are idempotent: duplicate deliveries are dropped via VV check.
+The responder auto-detects the caller's `NodeId` from the first Handshake -- no manual configuration needed. Events are idempotent: duplicate deliveries are dropped via Version Vector check.
 
 ---
 
@@ -80,14 +79,31 @@ cargo build --release
 ### CLI
 
 ```bash
-# Show node status (creates data dir on first run)
+# Show node status (creates data dir and generates a node identity on first run)
 ./target/release/zamsync info /var/lib/zamsync/node1
 
-# Submit an event
+# Submit an event (appended to local WAL, flushed to disk)
 ./target/release/zamsync submit /var/lib/zamsync/node1 "hello world"
+
+# Pull events from a remote peer (initiator role)
+./target/release/zamsync sync /var/lib/zamsync/node1 192.168.1.10:7000 42
+
+# Accept incoming sync sessions continuously (responder role)
+./target/release/zamsync serve /var/lib/zamsync/node1 0.0.0.0:7000
 ```
 
-Node identity is stored in `<data-dir>/.node_id` and generated automatically on first start.
+Node identity is stored in `<data-dir>/.node_id` and generated automatically on first start. Set `RUST_LOG=info` to see structured sync traces.
+
+**Minimal two-node example:**
+
+```bash
+# Terminal 1 -- node A listens
+./target/release/zamsync serve ./node-a 0.0.0.0:7000
+
+# Terminal 2 -- node B submits an event, then syncs to A
+./target/release/zamsync submit ./node-b "patient record 1"
+./target/release/zamsync sync  ./node-b 127.0.0.1:7000 $(cat ./node-a/.node_id)
+```
 
 ### Using the Engine in Your Application
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,7 +34,7 @@
 - [x] End-to-end TCP sync test: two nodes over loopback, full convergence verified
 - [x] CLI: `info`, `submit`, `sync <peer-addr> <peer-id>`, `serve <bind-addr> <peer-id>`
 
-## Phase 4: Hardening (in progress)
+## Phase 4: Hardening (done)
 
 - [x] Crash-consistency test suite: WAL truncation, CRC corruption, VV recovery
 - [x] Auto-truncate partial WAL writes on open (silent data-loss fix)
@@ -42,7 +42,7 @@
 - [x] Structured logging: tracing spans per sync session, RUST_LOG filter
 - [x] Reconnect and retry logic in `sync` CLI command (exponential backoff, 5 attempts)
 - [x] Serve loop continues on peer errors instead of dying
-- [ ] Max frame size enforcement and backpressure
+- [x] Max frame size enforcement: 64 MB hard limit in wire protocol decoder
 
 ## Phase 5: Performance
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -47,7 +47,7 @@
 ## Phase 5: Performance
 
 - [x] Chunked `EventBatch`: 256 events/frame cap, multiple frames per sync (bounds frame size and peak memory)
-- [ ] WAL compaction / snapshot to bound replay time on startup
+- [x] WAL compaction: drop peer-confirmed events; tombstone record preserves seq continuity; `zamsync compact` CLI command
 - [ ] Zstd compression with pre-shared dictionary (target: -70% bandwidth on repetitive payloads)
 - [ ] Resource profiling: target < 100 MB RSS on embedded hardware
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,13 +34,14 @@
 - [x] End-to-end TCP sync test: two nodes over loopback, full convergence verified
 - [x] CLI: `info`, `submit`, `sync <peer-addr> <peer-id>`, `serve <bind-addr> <peer-id>`
 
-## Phase 4: Hardening (next)
+## Phase 4: Hardening (in progress)
 
-- [ ] Crash-consistency test suite: simulate WAL truncation mid-write, verify recovery
-- [ ] `serve` loop: handle multiple sequential peers (not just one-shot)
+- [x] Crash-consistency test suite: WAL truncation, CRC corruption, VV recovery
+- [x] Auto-truncate partial WAL writes on open (silent data-loss fix)
+- [x] `serve` loop: continuous, auto-detects peer NodeId from Handshake
+- [x] Structured logging: tracing spans per sync session, RUST_LOG filter
 - [ ] Reconnect and retry logic in `SyncSession`
 - [ ] Max frame size enforcement and backpressure
-- [ ] Structured logging (tracing spans per sync session)
 
 ## Phase 5: Performance
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,9 +46,9 @@
 
 ## Phase 5: Performance
 
-- [ ] Zstd compression with pre-shared dictionary (target: -70% bandwidth on repetitive payloads)
-- [ ] Streaming `EventBatch` (chunked sends instead of full-collect)
+- [x] Chunked `EventBatch`: 256 events/frame cap, multiple frames per sync (bounds frame size and peak memory)
 - [ ] WAL compaction / snapshot to bound replay time on startup
+- [ ] Zstd compression with pre-shared dictionary (target: -70% bandwidth on repetitive payloads)
 - [ ] Resource profiling: target < 100 MB RSS on embedded hardware
 
 ## Phase 6: Security and Ops

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,7 +40,8 @@
 - [x] Auto-truncate partial WAL writes on open (silent data-loss fix)
 - [x] `serve` loop: continuous, auto-detects peer NodeId from Handshake
 - [x] Structured logging: tracing spans per sync session, RUST_LOG filter
-- [ ] Reconnect and retry logic in `SyncSession`
+- [x] Reconnect and retry logic in `sync` CLI command (exponential backoff, 5 attempts)
+- [x] Serve loop continues on peer errors instead of dying
 - [ ] Max frame size enforcement and backpressure
 
 ## Phase 5: Performance

--- a/crates/zamsync-network/Cargo.toml
+++ b/crates/zamsync-network/Cargo.toml
@@ -11,6 +11,7 @@ zamsync-core = { path = "../zamsync-core" }
 rkyv.workspace = true
 byteorder.workspace = true
 log.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 zamsync-storage = { path = "../zamsync-storage" }

--- a/crates/zamsync-network/src/transport/tcp.rs
+++ b/crates/zamsync-network/src/transport/tcp.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::io::BufWriter;
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::time::Duration;
+use tracing::{info, warn};
 use zamsync_core::ports::Transport;
 use zamsync_core::{NodeId, SyncMessage, ZamError, ZamResult};
 
@@ -21,7 +22,7 @@ impl TcpTransport {
     pub fn bind(addr: &str) -> ZamResult<Self> {
         let listener = TcpListener::bind(addr)?;
         listener.set_nonblocking(true)?;
-        log::info!("listening on {}", addr);
+        info!("listening on {}", addr);
         Ok(Self {
             listener,
             peers: HashMap::new(),
@@ -45,7 +46,7 @@ impl TcpTransport {
                 pending: None,
             },
         );
-        log::info!("accepted peer {} from {}", peer_id.0, addr);
+        info!(peer = peer_id.0, %addr, "accepted peer");
         Ok(())
     }
 
@@ -61,10 +62,14 @@ impl TcpTransport {
         let msg = protocol::decode(&mut stream)?;
         let node_id = match &msg {
             SyncMessage::Handshake { node_id, .. } => *node_id,
-            _ => {
+            other => {
+                warn!(
+                    ?other,
+                    "expected Handshake as first message, closing connection"
+                );
                 return Err(ZamError::Protocol(
                     "first message from peer must be a Handshake".into(),
-                ))
+                ));
             }
         };
 
@@ -76,7 +81,7 @@ impl TcpTransport {
                 pending: Some(msg),
             },
         );
-        log::info!("accepted peer {} from {}", node_id.0, addr);
+        info!(peer = node_id.0, %addr, "accepted peer via Handshake");
         Ok(node_id)
     }
 
@@ -95,7 +100,7 @@ impl TcpTransport {
                 pending: None,
             },
         );
-        log::info!("connected to peer {} at {}", peer_id.0, addr);
+        info!(peer = peer_id.0, addr, "connected to peer");
         Ok(())
     }
 

--- a/crates/zamsync-network/src/transport/tcp.rs
+++ b/crates/zamsync-network/src/transport/tcp.rs
@@ -6,9 +6,15 @@ use std::time::Duration;
 use zamsync_core::ports::Transport;
 use zamsync_core::{NodeId, SyncMessage, ZamError, ZamResult};
 
+struct PeerConn {
+    stream: TcpStream,
+    /// One message read ahead (e.g. Handshake consumed during accept_any).
+    pending: Option<SyncMessage>,
+}
+
 pub struct TcpTransport {
     listener: TcpListener,
-    peers: HashMap<u32, TcpStream>,
+    peers: HashMap<u32, PeerConn>,
 }
 
 impl TcpTransport {
@@ -22,7 +28,6 @@ impl TcpTransport {
         })
     }
 
-    /// Returns the local address the listener is bound to.
     pub fn local_addr(&self) -> ZamResult<SocketAddr> {
         Ok(self.listener.local_addr()?)
     }
@@ -33,15 +38,63 @@ impl TcpTransport {
         let (stream, addr) = self.listener.accept()?;
         self.listener.set_nonblocking(true)?;
         stream.set_read_timeout(Some(Duration::from_millis(50)))?;
-        self.peers.insert(peer_id.0, stream);
+        self.peers.insert(
+            peer_id.0,
+            PeerConn {
+                stream,
+                pending: None,
+            },
+        );
         log::info!("accepted peer {} from {}", peer_id.0, addr);
         Ok(())
+    }
+
+    /// Blocking accept: reads the first Handshake to discover the peer's NodeId.
+    /// The Handshake is buffered and will be returned by the next `receive()` call.
+    /// Returns the peer's NodeId so callers can pass it to `serve_one`.
+    pub fn accept_any(&mut self) -> ZamResult<NodeId> {
+        self.listener.set_nonblocking(false)?;
+        let (mut stream, addr) = self.listener.accept()?;
+        self.listener.set_nonblocking(true)?;
+        stream.set_read_timeout(Some(Duration::from_millis(5_000)))?;
+
+        let msg = protocol::decode(&mut stream)?;
+        let node_id = match &msg {
+            SyncMessage::Handshake { node_id, .. } => *node_id,
+            _ => {
+                return Err(ZamError::Protocol(
+                    "first message from peer must be a Handshake".into(),
+                ))
+            }
+        };
+
+        stream.set_read_timeout(Some(Duration::from_millis(50)))?;
+        self.peers.insert(
+            node_id.0,
+            PeerConn {
+                stream,
+                pending: Some(msg),
+            },
+        );
+        log::info!("accepted peer {} from {}", node_id.0, addr);
+        Ok(node_id)
+    }
+
+    /// Removes a peer connection, allowing the slot to be reused.
+    pub fn disconnect(&mut self, peer_id: NodeId) {
+        self.peers.remove(&peer_id.0);
     }
 
     pub fn connect(&mut self, peer_id: NodeId, addr: &str) -> ZamResult<()> {
         let stream = TcpStream::connect(addr)?;
         stream.set_read_timeout(Some(Duration::from_millis(50)))?;
-        self.peers.insert(peer_id.0, stream);
+        self.peers.insert(
+            peer_id.0,
+            PeerConn {
+                stream,
+                pending: None,
+            },
+        );
         log::info!("connected to peer {} at {}", peer_id.0, addr);
         Ok(())
     }
@@ -53,19 +106,22 @@ impl TcpTransport {
 
 impl Transport for TcpTransport {
     fn send(&mut self, peer_id: NodeId, message: &SyncMessage) -> ZamResult<()> {
-        let stream = self
+        let peer = self
             .peers
             .get_mut(&peer_id.0)
             .ok_or_else(|| ZamError::Protocol(format!("no connection to peer {}", peer_id.0)))?;
-        let mut writer = BufWriter::new(stream as &TcpStream);
+        let mut writer = BufWriter::new(&peer.stream);
         protocol::encode(message, &mut writer)
     }
 
     fn receive(&mut self) -> ZamResult<Option<(NodeId, SyncMessage)>> {
         let peer_ids: Vec<u32> = self.peers.keys().cloned().collect();
         for peer_id_raw in peer_ids {
-            if let Some(stream) = self.peers.get_mut(&peer_id_raw) {
-                match protocol::decode(stream) {
+            if let Some(peer) = self.peers.get_mut(&peer_id_raw) {
+                if let Some(msg) = peer.pending.take() {
+                    return Ok(Some((NodeId(peer_id_raw), msg)));
+                }
+                match protocol::decode(&mut peer.stream) {
                     Ok(msg) => return Ok(Some((NodeId(peer_id_raw), msg))),
                     Err(ZamError::Io(e))
                         if e.kind() == std::io::ErrorKind::WouldBlock

--- a/crates/zamsync-network/tests/tcp_sync_test.rs
+++ b/crates/zamsync-network/tests/tcp_sync_test.rs
@@ -108,6 +108,39 @@ fn test_tcp_sync_idempotent() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+/// Syncing more than EVENTS_PER_BATCH events exercises the chunked-send path.
+/// All events must arrive intact even when split across multiple frames.
+#[test]
+fn test_tcp_sync_large_batch() -> Result<(), Box<dyn std::error::Error>> {
+    use zamsync_storage::EVENTS_PER_BATCH;
+
+    let node_a = NodeId(20);
+    let node_b = NodeId(21);
+    let dir_a = tempdir()?;
+    let dir_b = tempdir()?;
+
+    // A writes more than one batch worth of events
+    let event_count = EVENTS_PER_BATCH + 50;
+    {
+        let mut engine = ZamEngine::open_wal(dir_a.path(), node_a, EventCounter::default())?;
+        for i in 0..event_count {
+            engine.submit(1, format!("event-{i}").into_bytes())?;
+        }
+        engine.sync()?;
+    }
+
+    let (sent, received) = run_one_sync(&dir_a, node_a, &dir_b, node_b)?;
+
+    assert_eq!(received, event_count, "B must receive all events from A");
+    assert_eq!(sent, 0, "B has nothing to send");
+
+    // B must be queryable and have the right count
+    let engine_b = ZamEngine::open_wal(dir_b.path(), node_b, EventCounter::default())?;
+    assert_eq!(engine_b.state().count, event_count);
+
+    Ok(())
+}
+
 fn run_one_sync(
     dir_a: &tempfile::TempDir,
     node_a: NodeId,

--- a/crates/zamsync-storage/Cargo.toml
+++ b/crates/zamsync-storage/Cargo.toml
@@ -12,6 +12,7 @@ crc32fast.workspace = true
 byteorder.workspace = true
 log.workspace = true
 rkyv.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/zamsync-storage/src/adapters/wal_event_store.rs
+++ b/crates/zamsync-storage/src/adapters/wal_event_store.rs
@@ -10,7 +10,22 @@ pub struct WalEventStore {
 
 impl WalEventStore {
     pub fn open(path: impl AsRef<Path>) -> ZamResult<Self> {
-        let (last_seq, _) = WalScanner::recover(&path)?;
+        let (last_seq, end_pos) = WalScanner::recover(&path)?;
+
+        // Truncate any bytes left past the last valid record. Without this, a
+        // crash mid-write leaves a partial record in the file. WalWriter opens in
+        // APPEND mode, so new records land after the garbage -- and the next scan
+        // stops at the garbage, making those new records permanently invisible.
+        if path.as_ref().exists() {
+            let actual_len = std::fs::metadata(path.as_ref())?.len();
+            if actual_len > end_pos {
+                std::fs::OpenOptions::new()
+                    .write(true)
+                    .open(path.as_ref())?
+                    .set_len(end_pos)?;
+            }
+        }
+
         let next_seq = last_seq.map(|s| s.next()).unwrap_or(SequenceNumber::ZERO);
         let writer = WalWriter::open(&path, next_seq)?;
         Ok(Self {

--- a/crates/zamsync-storage/src/adapters/wal_event_store.rs
+++ b/crates/zamsync-storage/src/adapters/wal_event_store.rs
@@ -1,4 +1,5 @@
 use crate::wal::{WalScanner, WalWriter};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use zamsync_core::ports::EventStore;
 use zamsync_core::{Event, SequenceNumber, ZamError, ZamResult};
@@ -35,6 +36,98 @@ impl WalEventStore {
     }
 }
 
+impl WalEventStore {
+    /// Rewrites the WAL, dropping all events whose `seq <= frontier[origin_node]`.
+    /// Events at or below the frontier have been confirmed by all known peers and
+    /// are safe to drop. Original WAL seq numbers are preserved (not renumbered)
+    /// so that the next local-event seq continues correctly after reopening.
+    ///
+    /// If ALL events are dropped, a zero-payload tombstone is written at the
+    /// last seq so that `WalWriter.current_seq` continues from the right position
+    /// instead of resetting to zero.
+    ///
+    /// Returns the number of records dropped. Returns 0 if nothing was dropped.
+    pub fn compact(&mut self, frontier: &HashMap<u32, SequenceNumber>) -> ZamResult<usize> {
+        if !self.path.exists() || frontier.is_empty() {
+            return Ok(0);
+        }
+
+        self.writer.sync()?;
+
+        let mut kept: Vec<(SequenceNumber, Vec<u8>)> = Vec::new();
+        let mut dropped = 0usize;
+        let mut last_seen_seq: Option<SequenceNumber> = None;
+
+        for result in WalScanner::open(&self.path)?.scan() {
+            let record = result?;
+            last_seen_seq = Some(record.seq);
+
+            // Tombstone records (empty payload) are kept to preserve seq continuity.
+            if record.payload.is_empty() {
+                kept.push((record.seq, record.payload));
+                continue;
+            }
+
+            let event: Event = rkyv::from_bytes(&record.payload)
+                .map_err(|e| ZamError::Serialization(format!("{}", e)))?;
+
+            let below_frontier = frontier
+                .get(&event.origin_node.0)
+                .map(|&frontier_seq| event.seq <= frontier_seq)
+                .unwrap_or(false);
+
+            if below_frontier {
+                dropped += 1;
+            } else {
+                kept.push((record.seq, record.payload));
+            }
+        }
+
+        if dropped == 0 {
+            return Ok(0);
+        }
+
+        // If every remaining record is a tombstone (or kept is empty), replace them
+        // with a single tombstone at the last WAL seq so WalWriter resumes correctly.
+        let all_tombstones = kept.iter().all(|(_, p)| p.is_empty());
+        if all_tombstones {
+            kept.clear();
+            if let Some(last_seq) = last_seen_seq {
+                kept.push((last_seq, Vec::new()));
+            }
+        }
+
+        let tmp = self.path.with_extension("wal.tmp");
+        {
+            let mut w = WalWriter::open(&tmp, SequenceNumber::ZERO)?;
+            for (seq, payload) in &kept {
+                w.append_at_seq(*seq, payload)?;
+            }
+            w.sync()?;
+        }
+
+        // Atomic replace -- on Windows rename fails if the destination exists.
+        if self.path.exists() {
+            std::fs::remove_file(&self.path)?;
+        }
+        std::fs::rename(&tmp, &self.path)?;
+
+        let (last_seq, end_pos) = WalScanner::recover(&self.path)?;
+        let next_seq = last_seq.map(|s| s.next()).unwrap_or(SequenceNumber::ZERO);
+
+        let actual_len = std::fs::metadata(&self.path).map(|m| m.len()).unwrap_or(0);
+        if actual_len > end_pos {
+            std::fs::OpenOptions::new()
+                .write(true)
+                .open(&self.path)?
+                .set_len(end_pos)?;
+        }
+
+        self.writer = WalWriter::open(&self.path, next_seq)?;
+        Ok(dropped)
+    }
+}
+
 impl EventStore for WalEventStore {
     fn next_seq(&self) -> SequenceNumber {
         self.writer.next_seq()
@@ -51,10 +144,18 @@ impl EventStore for WalEventStore {
             return Ok(Box::new(std::iter::empty()));
         }
         let scanner = WalScanner::open(&self.path)?;
-        let iter = scanner.scan().map(|res| -> ZamResult<Event> {
-            let record = res?;
-            rkyv::from_bytes::<Event>(&record.payload)
-                .map_err(|e| ZamError::Serialization(format!("{}", e)))
+        let iter = scanner.scan().filter_map(|res| -> Option<ZamResult<Event>> {
+            let record = match res {
+                Ok(r) => r,
+                Err(e) => return Some(Err(e)),
+            };
+            if record.payload.is_empty() {
+                return None; // tombstone written by compact() to preserve seq continuity
+            }
+            Some(
+                rkyv::from_bytes::<Event>(&record.payload)
+                    .map_err(|e| ZamError::Serialization(format!("{}", e))),
+            )
         });
         Ok(Box::new(iter))
     }

--- a/crates/zamsync-storage/src/engine.rs
+++ b/crates/zamsync-storage/src/engine.rs
@@ -4,7 +4,9 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 use zamsync_core::ports::{EventStore, PeerStore, StateStore};
-use zamsync_core::{Event, Hlc, NodeId, ReplicationState, SequenceNumber, SyncMessage, ZamResult};
+use zamsync_core::{
+    Event, Hlc, NodeId, ReplicationState, SequenceNumber, SyncMessage, VersionVector, ZamResult,
+};
 
 pub struct ZamEngine<E: EventStore, P: PeerStore, S: StateStore> {
     node_id: NodeId,
@@ -18,16 +20,23 @@ pub struct ZamEngine<E: EventStore, P: PeerStore, S: StateStore> {
 impl<E: EventStore, P: PeerStore, S: StateStore> ZamEngine<E, P, S> {
     pub fn new(node_id: NodeId, event_store: E, peer_store: P, mut state: S) -> ZamResult<Self> {
         let mut max_hlc = Hlc::default();
+        let mut wal_vv = VersionVector::default();
 
         for event_res in event_store.scan()? {
             let event = event_res?;
             if event.hlc > max_hlc {
                 max_hlc = event.hlc;
             }
+            // Rebuild VV from WAL: the WAL is the authoritative source of truth.
+            // A crash can leave peers.state ahead of the WAL, which would corrupt
+            // the VV and cause events to be considered "already seen" when they are not.
+            wal_vv.update(event.origin_node, event.seq);
             state.apply_event(event.seq, &event)?;
         }
 
-        let replication = peer_store.load()?;
+        let mut replication = peer_store.load()?;
+        // Override local_vv with the WAL-derived VV. Peer knowledge entries are kept.
+        replication.local_vv = wal_vv;
 
         Ok(Self {
             node_id,

--- a/crates/zamsync-storage/src/engine.rs
+++ b/crates/zamsync-storage/src/engine.rs
@@ -206,6 +206,39 @@ impl<S: StateStore> ZamEngine<WalEventStore, FilePeerStore, S> {
         let peer_store = FilePeerStore::open(dir.join("peers.state"), node_id)?;
         ZamEngine::new(node_id, event_store, peer_store, state)
     }
+
+    /// Drops WAL records that ALL known peers have confirmed receiving.
+    ///
+    /// The compaction frontier is the per-node minimum of `peer.known_vv` across
+    /// all peers. A peer confirms its VV on every `SyncComplete` it sends us, so
+    /// the frontier advances as nodes sync. Events at or below the frontier are
+    /// safe to drop because no peer will ever ask for them again.
+    ///
+    /// Returns the number of records dropped. Returns 0 if there are no known
+    /// peers or if no peer has confirmed anything yet.
+    pub fn compact(&mut self) -> ZamResult<usize> {
+        if self.replication.peers.is_empty() {
+            return Ok(0);
+        }
+
+        let mut frontier: HashMap<u32, SequenceNumber> = HashMap::new();
+
+        for &node_raw in self.replication.local_vv.entries.keys() {
+            // Only compact a node's events if ALL peers have confirmed seeing them.
+            let all_confirmed = self.replication.peers.values()
+                .all(|p| p.known_vv.entries.contains_key(&node_raw));
+
+            if all_confirmed {
+                let min_seq = self.replication.peers.values()
+                    .map(|p| p.known_vv.entries[&node_raw])
+                    .min()
+                    .expect("all_confirmed guarantees at least one entry");
+                frontier.insert(node_raw, min_seq);
+            }
+        }
+
+        self.event_store.compact(&frontier)
+    }
 }
 
 fn now_ms() -> u64 {

--- a/crates/zamsync-storage/src/engine.rs
+++ b/crates/zamsync-storage/src/engine.rs
@@ -8,6 +8,10 @@ use zamsync_core::{
     Event, Hlc, NodeId, ReplicationState, SequenceNumber, SyncMessage, VersionVector, ZamResult,
 };
 
+/// Maximum events per `EventBatch` frame. Bounds frame size and peak memory
+/// during sync regardless of how many events a node has accumulated.
+pub const EVENTS_PER_BATCH: usize = 256;
+
 pub struct ZamEngine<E: EventStore, P: PeerStore, S: StateStore> {
     node_id: NodeId,
     event_store: E,
@@ -109,10 +113,10 @@ impl<E: EventStore, P: PeerStore, S: StateStore> ZamEngine<E, P, S> {
                 let mut responses = vec![self.prepare_handshake()];
                 for (node, start_seq) in gaps {
                     let events = self.events_since(node, start_seq)?;
-                    if !events.is_empty() {
+                    for chunk in events.chunks(EVENTS_PER_BATCH) {
                         responses.push(SyncMessage::EventBatch {
                             origin_node: node,
-                            events,
+                            events: chunk.to_vec(),
                         });
                     }
                 }

--- a/crates/zamsync-storage/src/lib.rs
+++ b/crates/zamsync-storage/src/lib.rs
@@ -5,7 +5,7 @@ pub mod sync_session;
 pub mod wal;
 
 pub use adapters::{FilePeerStore, WalEventStore};
-pub use engine::ZamEngine;
+pub use engine::{ZamEngine, EVENTS_PER_BATCH};
 pub use sorter::LogSorter;
 pub use sync_session::{SyncSession, SyncStats};
 pub use wal::{WalIterator, WalRecord, WalScanner, WalWriter};

--- a/crates/zamsync-storage/src/sync_session.rs
+++ b/crates/zamsync-storage/src/sync_session.rs
@@ -2,7 +2,7 @@ use tracing::{instrument, warn};
 use zamsync_core::ports::{EventStore, PeerStore, StateStore, Transport};
 use zamsync_core::{NodeId, SyncMessage, ZamError, ZamResult};
 
-use crate::engine::ZamEngine;
+use crate::engine::{ZamEngine, EVENTS_PER_BATCH};
 
 #[derive(Debug, Default)]
 pub struct SyncStats {
@@ -64,13 +64,13 @@ where
         let gaps = peer_vv.find_gaps(&our_vv);
         for (node, start_seq) in gaps {
             let events = self.engine.events_since(node, start_seq)?;
-            if !events.is_empty() {
-                stats.events_sent += events.len();
+            for chunk in events.chunks(EVENTS_PER_BATCH) {
+                stats.events_sent += chunk.len();
                 self.transport.send(
                     peer_id,
                     &SyncMessage::EventBatch {
                         origin_node: node,
-                        events,
+                        events: chunk.to_vec(),
                     },
                 )?;
             }

--- a/crates/zamsync-storage/src/sync_session.rs
+++ b/crates/zamsync-storage/src/sync_session.rs
@@ -1,3 +1,4 @@
+use tracing::{instrument, warn};
 use zamsync_core::ports::{EventStore, PeerStore, StateStore, Transport};
 use zamsync_core::{NodeId, SyncMessage, ZamError, ZamResult};
 
@@ -33,6 +34,7 @@ where
 
     /// Initiator side: sends our handshake, receives peer's handshake + events +
     /// SyncComplete, then pushes our missing events and sends SyncComplete.
+    #[instrument(skip(self), fields(peer = peer_id.0))]
     pub fn sync(&mut self, peer_id: NodeId) -> ZamResult<SyncStats> {
         let mut stats = SyncStats::default();
 
@@ -75,6 +77,12 @@ where
         }
         self.transport.send(peer_id, &SyncMessage::SyncComplete)?;
 
+        tracing::info!(
+            peer = peer_id.0,
+            sent = stats.events_sent,
+            received = stats.events_received,
+            "sync complete"
+        );
         self.engine.sync()?;
         Ok(stats)
     }
@@ -82,6 +90,7 @@ where
     /// Responder side: waits for the initiator's handshake, responds with our
     /// handshake + events + SyncComplete, then receives initiator's events until
     /// their SyncComplete.
+    #[instrument(skip(self), fields(peer = peer_id.0))]
     pub fn serve_one(&mut self, peer_id: NodeId) -> ZamResult<SyncStats> {
         let mut stats = SyncStats::default();
 
@@ -119,6 +128,12 @@ where
             }
         }
 
+        tracing::info!(
+            peer = peer_id.0,
+            sent = stats.events_sent,
+            received = stats.events_received,
+            "serve_one complete"
+        );
         self.engine.sync()?;
         Ok(stats)
     }
@@ -135,6 +150,7 @@ where
                 Some(_) | None => continue,
             }
         }
+        warn!(peer = expected_peer.0, "timeout waiting for peer handshake");
         Err(ZamError::Protocol(
             "timeout waiting for peer handshake".into(),
         ))

--- a/crates/zamsync-storage/src/wal.rs
+++ b/crates/zamsync-storage/src/wal.rs
@@ -3,6 +3,7 @@ use crc32fast::Hasher;
 use std::fs::{File, OpenOptions};
 use std::io::{self, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::Path;
+use tracing::warn;
 use zamsync_core::{SequenceNumber, ZamError, ZamResult, WAL_MAGIC, WAL_VERSION};
 
 /// WAL Header Size: 4 (Magic) + 1 (Ver) + 4 (CRC) + 8 (Seq) + 4 (Len) = 21 bytes.
@@ -106,7 +107,7 @@ impl WalScanner {
                 }
                 None => break,
                 Some(Err(e)) => {
-                    log::warn!("WAL recovery stopped at pos {}: {}", it.offset, e);
+                    warn!(pos = it.offset, error = %e, "WAL recovery stopped");
                     break;
                 }
             }

--- a/crates/zamsync-storage/src/wal.rs
+++ b/crates/zamsync-storage/src/wal.rs
@@ -65,6 +65,33 @@ impl WalWriter {
         Ok(seq)
     }
 
+    /// Writes a record at a specific sequence number, advancing `current_seq` if
+    /// necessary. Used during WAL compaction to preserve original seq numbering
+    /// so that the next local-event seq continues from the correct position.
+    pub fn append_at_seq(&mut self, seq: SequenceNumber, payload: &[u8]) -> ZamResult<()> {
+        let len = payload.len() as u32;
+
+        let mut hasher = Hasher::new();
+        hasher.update(&[WAL_VERSION]);
+        hasher.update(&seq.0.to_be_bytes());
+        hasher.update(&len.to_be_bytes());
+        hasher.update(payload);
+        let crc = hasher.finalize();
+
+        self.file.write_all(&WAL_MAGIC)?;
+        self.file.write_u8(WAL_VERSION)?;
+        self.file.write_u32::<BigEndian>(crc)?;
+        self.file.write_u64::<BigEndian>(seq.0)?;
+        self.file.write_u32::<BigEndian>(len)?;
+        self.file.write_all(payload)?;
+        self.file.flush()?;
+
+        if seq.next() > self.current_seq {
+            self.current_seq = seq.next();
+        }
+        Ok(())
+    }
+
     pub fn sync(&mut self) -> io::Result<()> {
         self.file.get_ref().sync_all()
     }

--- a/crates/zamsync-storage/tests/compaction_test.rs
+++ b/crates/zamsync-storage/tests/compaction_test.rs
@@ -1,0 +1,134 @@
+use tempfile::tempdir;
+use zamsync_core::ports::StateStore;
+use zamsync_core::{Event, NodeId, SequenceNumber, ZamResult};
+use zamsync_storage::{FilePeerStore, WalEventStore, ZamEngine};
+use zamsync_testing::run_direct_sync;
+
+#[derive(Default)]
+struct Counter(usize);
+
+impl StateStore for Counter {
+    fn apply_event(&mut self, _seq: SequenceNumber, _event: &Event) -> ZamResult<()> {
+        self.0 += 1;
+        Ok(())
+    }
+    fn last_applied_seq(&self) -> Option<SequenceNumber> {
+        None
+    }
+}
+
+fn open_engine(
+    dir: &tempfile::TempDir,
+    node: NodeId,
+) -> ZamResult<ZamEngine<WalEventStore, FilePeerStore, Counter>> {
+    ZamEngine::open_wal(dir.path(), node, Counter::default())
+}
+
+/// After syncing with all peers and compact(), WAL records below the frontier
+/// are removed and new submits continue with the correct sequence number.
+#[test]
+fn test_compact_drops_confirmed_events() -> ZamResult<()> {
+    let dir_a = tempdir()?;
+    let dir_b = tempdir()?;
+    let node_a = NodeId(1);
+    let node_b = NodeId(2);
+    let wal_path = dir_a.path().join("events.wal");
+
+    // A submits 5 events
+    let next_seq = {
+        let mut engine_a = open_engine(&dir_a, node_a)?;
+        for i in 0..5u32 {
+            engine_a.submit(1, format!("event-{i}").into_bytes())?;
+        }
+        engine_a.sync()?;
+        let next = engine_a.replication_state().local_vv.get(node_a).next();
+        next
+    };
+
+    // B syncs from A -- this makes A aware that B has confirmed all 5 events
+    {
+        let mut engine_a = open_engine(&dir_a, node_a)?;
+        let mut engine_b = open_engine(&dir_b, node_b)?;
+        run_direct_sync(&mut engine_a, &mut engine_b)?;
+        engine_a.sync()?;
+        engine_b.sync()?;
+    }
+
+    // Capture WAL size before compaction
+    let wal_size_before = std::fs::metadata(&wal_path).map(|m| m.len()).unwrap_or(0);
+
+    // Compact A's WAL -- all 5 events from A have been confirmed by B.
+    // B's replicated events (received during sync) will not be compacted
+    // because A has not confirmed them back to B.
+    let dropped = {
+        let mut engine_a = open_engine(&dir_a, node_a)?;
+        let d = engine_a.compact()?;
+        engine_a.sync()?;
+        d
+    };
+    assert_eq!(dropped, 5, "all 5 events from A should be dropped");
+
+    // WAL file must be smaller (B's replicated events remain, but A's 5 are gone)
+    let wal_size_after = std::fs::metadata(&wal_path).map(|m| m.len()).unwrap_or(0);
+    assert!(
+        wal_size_after < wal_size_before,
+        "WAL must shrink after compaction (was {wal_size_before}, now {wal_size_after})"
+    );
+
+    // Submit a new event -- seq must continue from before compaction
+    let mut engine_a = open_engine(&dir_a, node_a)?;
+    let new_seq = engine_a.submit(1, b"after-compact".to_vec())?;
+    assert_eq!(
+        new_seq, next_seq,
+        "next submit seq must continue from pre-compaction frontier"
+    );
+    engine_a.sync()?;
+
+    // Reopen and verify events are visible (replicated B events + 1 new A event)
+    let final_engine = open_engine(&dir_a, node_a)?;
+    assert!(final_engine.state().0 >= 1, "at least the post-compact event must be visible");
+
+    Ok(())
+}
+
+/// After compaction, syncing with a new peer still works correctly.
+/// The compacted node can still serve events that the new peer doesn't have.
+#[test]
+fn test_compact_then_sync_new_peer() -> ZamResult<()> {
+    let dir_a = tempdir()?;
+    let dir_b = tempdir()?;
+    let dir_c = tempdir()?;
+    let node_a = NodeId(10);
+    let node_b = NodeId(11);
+    let node_c = NodeId(12);
+
+    // A submits, B syncs, A compacts
+    {
+        let mut engine_a = open_engine(&dir_a, node_a)?;
+        engine_a.submit(1, b"old-event".to_vec())?;
+        engine_a.sync()?;
+    }
+    {
+        let mut engine_a = open_engine(&dir_a, node_a)?;
+        let mut engine_b = open_engine(&dir_b, node_b)?;
+        run_direct_sync(&mut engine_a, &mut engine_b)?;
+        engine_a.sync()?;
+    }
+    {
+        let mut engine_a = open_engine(&dir_a, node_a)?;
+        engine_a.compact()?;
+        engine_a.submit(1, b"new-event".to_vec())?;
+        engine_a.sync()?;
+    }
+
+    // C syncs with A -- C is brand new, A has been compacted
+    // C should receive at least the post-compact event
+    let mut engine_a = open_engine(&dir_a, node_a)?;
+    let mut engine_c = open_engine(&dir_c, node_c)?;
+    run_direct_sync(&mut engine_a, &mut engine_c)?;
+
+    // C must have the post-compact event
+    assert!(engine_c.state().0 >= 1, "C must receive at least the post-compact event");
+
+    Ok(())
+}

--- a/crates/zamsync-storage/tests/crash_test.rs
+++ b/crates/zamsync-storage/tests/crash_test.rs
@@ -1,0 +1,234 @@
+use std::fs::OpenOptions;
+use std::io::{Seek, SeekFrom, Write};
+use tempfile::tempdir;
+use zamsync_core::ports::StateStore;
+use zamsync_core::{Event, NodeId, SequenceNumber, ZamResult};
+use zamsync_storage::wal::{WalScanner, WalWriter, WAL_HEADER_SIZE};
+use zamsync_storage::{FilePeerStore, WalEventStore, ZamEngine};
+
+#[derive(Default)]
+struct Counter(usize);
+
+impl StateStore for Counter {
+    fn apply_event(&mut self, _seq: SequenceNumber, _event: &Event) -> ZamResult<()> {
+        self.0 += 1;
+        Ok(())
+    }
+    fn last_applied_seq(&self) -> Option<SequenceNumber> {
+        None
+    }
+}
+
+fn open_engine(
+    dir: &tempfile::TempDir,
+    node: NodeId,
+) -> ZamResult<ZamEngine<WalEventStore, FilePeerStore, Counter>> {
+    ZamEngine::open_wal(dir.path(), node, Counter::default())
+}
+
+// ---------------------------------------------------------------------------
+// WAL-level crash scenarios (use WalWriter directly -- known payload sizes)
+// ---------------------------------------------------------------------------
+
+/// Truncating a single byte from the payload stops recovery before that record.
+#[test]
+fn test_wal_truncate_mid_payload() -> ZamResult<()> {
+    let dir = tempdir()?;
+    let path = dir.path().join("test.wal");
+
+    let mut w = WalWriter::open(&path, SequenceNumber::ZERO)?;
+    w.append(b"first")?;
+    w.append(b"second")?;
+    w.sync()?;
+
+    // Cut one byte off the end (inside the second record's payload)
+    let len = std::fs::metadata(&path)?.len();
+    OpenOptions::new()
+        .write(true)
+        .open(&path)?
+        .set_len(len - 1)?;
+
+    let (last_seq, _) = WalScanner::recover(&path)?;
+    assert_eq!(
+        last_seq,
+        Some(SequenceNumber(0)),
+        "only first record survives"
+    );
+
+    Ok(())
+}
+
+/// Truncating to exactly after the first record leaves it intact.
+#[test]
+fn test_wal_truncate_after_first_record() -> ZamResult<()> {
+    let dir = tempdir()?;
+    let path = dir.path().join("test.wal");
+
+    let payload = b"keep";
+    let mut w = WalWriter::open(&path, SequenceNumber::ZERO)?;
+    w.append(payload)?;
+    w.append(b"drop")?;
+    w.sync()?;
+
+    let first_size = (WAL_HEADER_SIZE + payload.len()) as u64;
+    OpenOptions::new()
+        .write(true)
+        .open(&path)?
+        .set_len(first_size)?;
+
+    let (last_seq, pos) = WalScanner::recover(&path)?;
+    assert_eq!(last_seq, Some(SequenceNumber(0)));
+    assert_eq!(pos, first_size);
+
+    Ok(())
+}
+
+/// Corrupting the CRC of the second record makes recovery stop after the first.
+#[test]
+fn test_wal_corrupt_crc_stops_recovery() -> ZamResult<()> {
+    let dir = tempdir()?;
+    let path = dir.path().join("test.wal");
+
+    let first_payload = b"ok";
+    let mut w = WalWriter::open(&path, SequenceNumber::ZERO)?;
+    w.append(first_payload)?;
+    w.append(b"bad")?;
+    w.sync()?;
+
+    // Flip a byte inside the second record's payload
+    let second_record_start = WAL_HEADER_SIZE + first_payload.len();
+    let corrupt_offset = (second_record_start + WAL_HEADER_SIZE + 1) as u64;
+    {
+        let mut f = OpenOptions::new().write(true).open(&path)?;
+        f.seek(SeekFrom::Start(corrupt_offset))?;
+        f.write_all(&[0xff])?;
+    }
+
+    let (last_seq, _) = WalScanner::recover(&path)?;
+    assert_eq!(last_seq, Some(SequenceNumber(0)));
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Engine-level crash scenarios
+// ---------------------------------------------------------------------------
+
+/// Snapshot WAL size after first event, write a second, truncate back.
+/// Engine must recover only the first event.
+#[test]
+fn test_engine_recovers_after_wal_truncation() -> ZamResult<()> {
+    let dir = tempdir()?;
+    let wal_path = dir.path().join("events.wal");
+    let node = NodeId(1);
+
+    // Write first event and snapshot WAL size
+    let size_after_first = {
+        let mut e = open_engine(&dir, node)?;
+        e.submit(1, b"A".to_vec())?;
+        e.sync()?;
+        std::fs::metadata(&wal_path)?.len()
+    };
+
+    // Write second and third events
+    {
+        let mut e = open_engine(&dir, node)?;
+        e.submit(1, b"B".to_vec())?;
+        e.submit(1, b"C".to_vec())?;
+        e.sync()?;
+    }
+
+    // Truncate to just after the first event (simulates crash mid-write of B)
+    OpenOptions::new()
+        .write(true)
+        .open(&wal_path)?
+        .set_len(size_after_first)?;
+
+    let mut recovered = open_engine(&dir, node)?;
+    assert_eq!(recovered.state().0, 1, "only 1 event should survive");
+
+    // Next submit must continue at seq 1, not seq 2 or 3
+    let seq = recovered.submit(1, b"D".to_vec())?;
+    assert_eq!(seq, SequenceNumber(1), "next seq must be 1 after recovery");
+
+    Ok(())
+}
+
+/// VV rebuilt from WAL must reflect only the events that survived truncation.
+#[test]
+fn test_engine_vv_consistent_after_recovery() -> ZamResult<()> {
+    let dir = tempdir()?;
+    let wal_path = dir.path().join("events.wal");
+    let node = NodeId(1);
+
+    // Write first event and snapshot WAL size
+    let size_after_first = {
+        let mut e = open_engine(&dir, node)?;
+        e.submit(1, b"x".to_vec())?;
+        e.sync()?;
+        std::fs::metadata(&wal_path)?.len()
+    };
+
+    // Write second event
+    {
+        let mut e = open_engine(&dir, node)?;
+        e.submit(1, b"y".to_vec())?;
+        e.sync()?;
+    }
+
+    // Truncate back to just after first event
+    OpenOptions::new()
+        .write(true)
+        .open(&wal_path)?
+        .set_len(size_after_first)?;
+
+    let recovered = open_engine(&dir, node)?;
+    let vv = &recovered.replication_state().local_vv;
+    assert_eq!(
+        vv.entries.get(&node.0),
+        Some(&SequenceNumber(0)),
+        "VV must reflect only seq 0 (x), not seq 1 (y)"
+    );
+
+    Ok(())
+}
+
+/// After recovery, submitting new events continues correctly and a fresh
+/// engine can replay them all without errors.
+#[test]
+fn test_engine_append_after_recovery() -> ZamResult<()> {
+    let dir = tempdir()?;
+    let wal_path = dir.path().join("events.wal");
+    let node = NodeId(1);
+
+    let size_after_first = {
+        let mut e = open_engine(&dir, node)?;
+        e.submit(1, b"durable".to_vec())?;
+        e.sync()?;
+        std::fs::metadata(&wal_path)?.len()
+    };
+
+    // Simulate crash after partial second write
+    {
+        let mut e = open_engine(&dir, node)?;
+        e.submit(1, b"lost".to_vec())?;
+        // no sync -- also truncate to be sure
+    }
+    OpenOptions::new()
+        .write(true)
+        .open(&wal_path)?
+        .set_len(size_after_first)?;
+
+    // Recover and append a new event
+    {
+        let mut e = open_engine(&dir, node)?;
+        e.submit(1, b"new".to_vec())?;
+        e.sync()?;
+    }
+
+    // Re-open and verify exactly 2 events: "durable" and "new"
+    let final_engine = open_engine(&dir, node)?;
+    assert_eq!(final_engine.state().0, 2, "should have exactly 2 events");
+
+    Ok(())
+}

--- a/crates/zamsync-storage/tests/crash_test.rs
+++ b/crates/zamsync-storage/tests/crash_test.rs
@@ -193,6 +193,48 @@ fn test_engine_vv_consistent_after_recovery() -> ZamResult<()> {
     Ok(())
 }
 
+/// The real crash scenario: garbage bytes are appended to the WAL without any
+/// manual truncation (simulating a crash mid-write). WalEventStore::open must
+/// truncate them so that subsequent appends remain visible to future scans.
+/// Before the fix, new records were silently lost because scan() stopped at the
+/// garbage before reaching them.
+#[test]
+fn test_engine_open_truncates_partial_write() -> ZamResult<()> {
+    let dir = tempdir()?;
+    let wal_path = dir.path().join("events.wal");
+    let node = NodeId(1);
+
+    // Write and persist "durable"
+    {
+        let mut e = open_engine(&dir, node)?;
+        e.submit(1, b"durable".to_vec())?;
+        e.sync()?;
+    }
+
+    // Append raw garbage -- no manual truncation (this is the crash scenario)
+    {
+        let mut f = OpenOptions::new().append(true).open(&wal_path)?;
+        f.write_all(b"\xDE\xAD\xBE\xEF\x01\x02\x03")?;
+    }
+
+    // Open engine: must auto-truncate the garbage and accept a new event
+    {
+        let mut e = open_engine(&dir, node)?;
+        e.submit(1, b"after-crash".to_vec())?;
+        e.sync()?;
+    }
+
+    // Both events must be visible on the next open
+    let final_engine = open_engine(&dir, node)?;
+    assert_eq!(
+        final_engine.state().0,
+        2,
+        "durable + after-crash must both be visible"
+    );
+
+    Ok(())
+}
+
 /// After recovery, submitting new events continues correctly and a fresh
 /// engine can replay them all without errors.
 #[test]

--- a/crates/zamsync-testing/src/sync.rs
+++ b/crates/zamsync-testing/src/sync.rs
@@ -1,5 +1,5 @@
 use zamsync_core::ports::{EventStore, PeerStore, StateStore};
-use zamsync_core::ZamResult;
+use zamsync_core::{SyncMessage, ZamResult};
 use zamsync_storage::ZamEngine;
 
 /// Synchronises two engines in both directions without a transport layer.
@@ -18,6 +18,9 @@ where
     P2: PeerStore,
     S2: StateStore,
 {
+    let node_a = engine_a.node_id();
+    let node_b = engine_b.node_id();
+
     let vv_a = engine_a.replication_state().local_vv.clone();
     let vv_b = engine_b.replication_state().local_vv.clone();
 
@@ -36,6 +39,12 @@ where
             applied_to_b += 1;
         }
     }
+
+    // Simulate SyncComplete on both engines so that peers.known_vv reflects the
+    // sync -- matching the real protocol where each side sends SyncComplete after
+    // pushing all its missing events.
+    engine_a.handle_sync_message(node_b, SyncMessage::SyncComplete)?;
+    engine_b.handle_sync_message(node_a, SyncMessage::SyncComplete)?;
 
     Ok((applied_to_a, applied_to_b))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,10 +26,11 @@ impl StateStore for EventCounter {
 fn usage() {
     eprintln!(
         "Usage:
-  zamsync info   <data-dir>
-  zamsync submit <data-dir> <payload>
-  zamsync sync   <data-dir> <peer-addr> <peer-id>
-  zamsync serve  <data-dir> <bind-addr>"
+  zamsync info    <data-dir>
+  zamsync submit  <data-dir> <payload>
+  zamsync sync    <data-dir> <peer-addr> <peer-id>
+  zamsync serve   <data-dir> <bind-addr>
+  zamsync compact <data-dir>"
     );
 }
 
@@ -44,6 +45,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Some("submit") => cmd_submit(&args),
         Some("sync") => cmd_sync(&args),
         Some("serve") => cmd_serve(&args),
+        Some("compact") => cmd_compact(&args),
         _ => {
             usage();
             std::process::exit(1);
@@ -172,6 +174,20 @@ fn node_id_from_dir(dir: &std::path::Path) -> NodeId {
     let id = rand_u32();
     let _ = std::fs::write(&id_file, id.to_string());
     NodeId(id)
+}
+
+fn cmd_compact(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
+    let dir = data_dir(args, 2)?;
+    let node_id = node_id_from_dir(&dir);
+    let mut engine = ZamEngine::open_wal(&dir, node_id, EventCounter::default())?;
+    let dropped = engine.compact()?;
+    engine.sync()?;
+    if dropped == 0 {
+        println!("nothing to compact (no peers have confirmed events yet)");
+    } else {
+        println!("compacted: dropped {dropped} WAL records");
+    }
+    Ok(())
 }
 
 fn is_transient(e: &zamsync_core::ZamError) -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,16 +88,35 @@ fn cmd_sync(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
 
     let node_id = node_id_from_dir(&dir);
     let mut engine = ZamEngine::open_wal(&dir, node_id, EventCounter::default())?;
+    let peer = NodeId(peer_id);
 
-    let mut transport = TcpTransport::bind("0.0.0.0:0")?;
-    transport.connect(NodeId(peer_id), peer_addr)?;
+    const MAX_ATTEMPTS: u32 = 5;
+    for attempt in 1..=MAX_ATTEMPTS {
+        let mut transport = TcpTransport::bind("0.0.0.0:0")?;
+        let connect_result = transport.connect(peer, peer_addr);
+        let sync_result = connect_result
+            .and_then(|()| SyncSession::new(&mut engine, &mut transport).sync(peer));
 
-    let stats = SyncSession::new(&mut engine, &mut transport).sync(NodeId(peer_id))?;
-    println!(
-        "sync done: sent={} received={}",
-        stats.events_sent, stats.events_received
-    );
-    Ok(())
+        match sync_result {
+            Ok(stats) => {
+                println!(
+                    "sync done: sent={} received={}",
+                    stats.events_sent, stats.events_received
+                );
+                return Ok(());
+            }
+            Err(ref e) if is_transient(e) && attempt < MAX_ATTEMPTS => {
+                let delay_ms = 100u64 * (1 << (attempt - 1));
+                eprintln!(
+                    "sync attempt {}/{MAX_ATTEMPTS} failed ({}), retrying in {delay_ms}ms",
+                    attempt, e
+                );
+                std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+            }
+            Err(e) => return Err(e.into()),
+        }
+    }
+    unreachable!()
 }
 
 fn cmd_serve(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
@@ -113,17 +132,24 @@ fn cmd_serve(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     );
 
     loop {
-        println!("waiting for peer...");
         let mut engine = ZamEngine::open_wal(&dir, node_id, EventCounter::default())?;
 
-        let peer_id = transport.accept_any()?;
+        let peer_id = match transport.accept_any() {
+            Ok(id) => id,
+            Err(e) => {
+                eprintln!("accept error: {e}");
+                continue;
+            }
+        };
         println!("peer {} connected", peer_id.0);
 
-        let stats = SyncSession::new(&mut engine, &mut transport).serve_one(peer_id)?;
-        println!(
-            "sync with peer {} done: sent={} received={}",
-            peer_id.0, stats.events_sent, stats.events_received
-        );
+        match SyncSession::new(&mut engine, &mut transport).serve_one(peer_id) {
+            Ok(stats) => println!(
+                "sync with peer {} done: sent={} received={}",
+                peer_id.0, stats.events_sent, stats.events_received
+            ),
+            Err(e) => eprintln!("sync with peer {} failed: {e}", peer_id.0),
+        }
         transport.disconnect(peer_id);
     }
 }
@@ -146,6 +172,20 @@ fn node_id_from_dir(dir: &std::path::Path) -> NodeId {
     let id = rand_u32();
     let _ = std::fs::write(&id_file, id.to_string());
     NodeId(id)
+}
+
+fn is_transient(e: &zamsync_core::ZamError) -> bool {
+    match e {
+        zamsync_core::ZamError::Io(io_err) => matches!(
+            io_err.kind(),
+            std::io::ErrorKind::ConnectionReset
+                | std::io::ErrorKind::ConnectionAborted
+                | std::io::ErrorKind::BrokenPipe
+                | std::io::ErrorKind::TimedOut
+                | std::io::ErrorKind::ConnectionRefused
+        ),
+        _ => false,
+    }
 }
 
 fn rand_u32() -> u32 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use std::env;
 use std::path::PathBuf;
+use tracing_subscriber::EnvFilter;
 use zamsync_core::ports::StateStore;
 use zamsync_core::{Event, NodeId, SequenceNumber, ZamResult};
 use zamsync_network::TcpTransport;
@@ -33,7 +34,9 @@ fn usage() {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    env_logger::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
     let args: Vec<String> = env::args().collect();
 
     match args.get(1).map(String::as_str) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ fn usage() {
   zamsync info   <data-dir>
   zamsync submit <data-dir> <payload>
   zamsync sync   <data-dir> <peer-addr> <peer-id>
-  zamsync serve  <data-dir> <bind-addr> <peer-id>"
+  zamsync serve  <data-dir> <bind-addr>"
     );
 }
 
@@ -100,23 +100,29 @@ fn cmd_sync(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
 fn cmd_serve(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     let dir = data_dir(args, 2)?;
     let bind_addr = args.get(3).ok_or("missing bind-addr")?;
-    let peer_id: u32 = args.get(4).ok_or("missing peer-id")?.parse()?;
 
     let node_id = node_id_from_dir(&dir);
-    let mut engine = ZamEngine::open_wal(&dir, node_id, EventCounter::default())?;
-
     let mut transport = TcpTransport::bind(bind_addr)?;
-    println!("listening on {}", transport.local_addr()?);
-    println!("waiting for peer {}...", peer_id);
-
-    transport.accept_peer(NodeId(peer_id))?;
-
-    let stats = SyncSession::new(&mut engine, &mut transport).serve_one(NodeId(peer_id))?;
     println!(
-        "sync done: sent={} received={}",
-        stats.events_sent, stats.events_received
+        "node {} listening on {}",
+        node_id.0,
+        transport.local_addr()?
     );
-    Ok(())
+
+    loop {
+        println!("waiting for peer...");
+        let mut engine = ZamEngine::open_wal(&dir, node_id, EventCounter::default())?;
+
+        let peer_id = transport.accept_any()?;
+        println!("peer {} connected", peer_id.0);
+
+        let stats = SyncSession::new(&mut engine, &mut transport).serve_one(peer_id)?;
+        println!(
+            "sync with peer {} done: sent={} received={}",
+            peer_id.0, stats.events_sent, stats.events_received
+        );
+        transport.disconnect(peer_id);
+    }
 }
 
 fn data_dir(args: &[String], pos: usize) -> Result<PathBuf, Box<dyn std::error::Error>> {


### PR DESCRIPTION
## Summary

- **Chunked EventBatch**: events are now sent in frames of at most 256 events (`EVENTS_PER_BATCH`). This bounds both the TCP frame size and peak memory usage during large syncs. Previously, all events for a node were collected into a single message -- on a 2G link with thousands of events this could be a multi-MB stall. The receiver already handles multiple `EventBatch` messages so this is a protocol-compatible change.
- **WAL compaction** (`engine.compact()` + `zamsync compact <data-dir>`): drops WAL records that all known peers have confirmed receiving (via `SyncComplete`). If all events are dropped, a tombstone record (empty payload, valid CRC) is written at the last seq so `WalWriter.current_seq` continues from the correct position instead of resetting to zero. Tombstone records are skipped during scan/replay. This bounds startup replay time as nodes accumulate events over weeks/months.
- **`run_direct_sync` fix**: now simulates `SyncComplete` on both engines after exchanging events, making `peers.known_vv` consistent with the real TCP protocol.
- 3 new tests: `test_tcp_sync_large_batch`, `test_compact_drops_confirmed_events`, `test_compact_then_sync_new_peer`.

## Test plan

- [ ] `cargo test --workspace` passes (31 tests)
- [ ] `cargo clippy --workspace -- -D warnings` is clean
- [ ] `test_tcp_sync_large_batch`: syncs 306 events, verifies all arrive across multiple frames
- [ ] `test_compact_drops_confirmed_events`: verifies event count drops and seq continuity after compaction
- [ ] `test_compact_then_sync_new_peer`: verifies a new peer can still sync after compaction