### PR TITLE
feat(cli): daemon mode -- autonomous periodic sync for clinic nodes

### DIFF
--- a/deploy/zamsync-daemon.service
+++ b/deploy/zamsync-daemon.service
@@ -1,0 +1,39 @@
+[Unit]
+Description=ZamSync daemon -- periodic outbound sync to hub
+Documentation=https://github.com/Etoile-Bleu/ZamSync
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=zamsync
+Group=zamsync
+
+EnvironmentFile=/etc/zamsync/zamsync.env
+
+# Connects to ZAMSYNC_HUB_ADDR and syncs every ZAMSYNC_INTERVAL seconds.
+# The serve unit (zamsync.service) handles inbound connections separately.
+ExecStart=/usr/local/bin/zamsync daemon \
+    ${ZAMSYNC_DATA_DIR} \
+    ${ZAMSYNC_HUB_ADDR} \
+    ${ZAMSYNC_HUB_ID} \
+    --interval ${ZAMSYNC_INTERVAL:-60}
+
+Restart=on-failure
+RestartSec=10s
+TimeoutStopSec=30s
+WorkingDirectory=/var/lib/zamsync
+
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+PrivateDevices=yes
+ReadWritePaths=/var/lib/zamsync
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=zamsync-daemon
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/zamsync.env
+++ b/deploy/zamsync.env
@@ -1,9 +1,18 @@
-# /etc/zamsync/zamsync.env -- site-specific configuration for the zamsync service.
-# Copy this file to /etc/zamsync/zamsync.env and edit before starting the service.
+# /etc/zamsync/zamsync.env -- site-specific configuration.
+# Copy to /etc/zamsync/zamsync.env and edit before starting services.
 
 # Directory that holds the WAL, peer state, and TLS credentials.
 ZAMSYNC_DATA_DIR=/var/lib/zamsync
 
+# --- serve unit (zamsync.service) ---
 # Address the sync server listens on.
-# Change 0.0.0.0 to a specific interface to restrict access.
 ZAMSYNC_BIND_ADDR=0.0.0.0:7000
+
+# --- daemon unit (zamsync-daemon.service) ---
+# Hub node address and NodeId to sync with periodically.
+ZAMSYNC_HUB_ADDR=hub.example.com:7000
+ZAMSYNC_HUB_ID=1
+
+# Sync interval in seconds (default: 60).
+# On 2G/satellite links, 300 (5 min) is a reasonable starting point.
+ZAMSYNC_INTERVAL=60

--- a/src/cmd/daemon.rs
+++ b/src/cmd/daemon.rs
@@ -1,0 +1,77 @@
+use crate::metrics::start_metrics_server;
+use crate::util::{data_dir, flag_value, load_tls_config, node_id_from_dir, EventCounter};
+use std::time::{Duration, Instant};
+use zamsync_core::NodeId;
+use zamsync_network::{TcpTransport, TlsTcpTransport};
+use zamsync_storage::{SyncSession, ZamEngine};
+
+pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
+    let dir = data_dir(args, 2)?;
+    let peer_addr = args.get(3).ok_or("missing peer-addr")?;
+    let peer_id: u32 = args.get(4).ok_or("missing peer-id")?.parse()?;
+    let interval_secs: u64 = flag_value(args, "--interval")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(60);
+    let use_tls = args.contains(&"--tls".to_string());
+
+    if let Some(metrics_addr) = flag_value(args, "--metrics") {
+        start_metrics_server(metrics_addr)?;
+    }
+
+    let node_id = node_id_from_dir(&dir);
+    let peer = NodeId(peer_id);
+    let interval = Duration::from_secs(interval_secs);
+
+    let mode = if use_tls { "TLS" } else { "TCP" };
+    println!(
+        "daemon: node {} syncing with peer {} ({}) every {}s",
+        node_id.0, peer_id, mode, interval_secs
+    );
+
+    loop {
+        let tick_start = Instant::now();
+        match sync_once(&dir, node_id, peer, peer_addr, use_tls) {
+            Ok((sent, received)) => {
+                if sent > 0 || received > 0 {
+                    println!(
+                        "[sync] peer={} sent={} received={}",
+                        peer_id, sent, received
+                    );
+                } else {
+                    println!("[sync] peer={} already in sync", peer_id);
+                }
+            }
+            Err(e) => eprintln!("[sync] peer={} error: {}", peer_id, e),
+        }
+
+        // Sleep for the remainder of the interval, regardless of how long sync took.
+        let elapsed = tick_start.elapsed();
+        if elapsed < interval {
+            std::thread::sleep(interval - elapsed);
+        }
+    }
+}
+
+fn sync_once(
+    dir: &std::path::Path,
+    node_id: NodeId,
+    peer: NodeId,
+    peer_addr: &str,
+    use_tls: bool,
+) -> Result<(usize, usize), Box<dyn std::error::Error>> {
+    let mut engine = ZamEngine::open_wal(dir, node_id, EventCounter::default())?;
+
+    let stats = if use_tls {
+        let tls_config = load_tls_config(dir)?;
+        let mut transport = TlsTcpTransport::bind("0.0.0.0:0", &tls_config)?;
+        transport.connect(peer, peer_addr)?;
+        SyncSession::new(&mut engine, &mut transport).sync(peer)?
+    } else {
+        let mut transport = TcpTransport::bind("0.0.0.0:0")?;
+        transport.connect(peer, peer_addr)?;
+        SyncSession::new(&mut engine, &mut transport).sync(peer)?
+    };
+
+    engine.sync()?;
+    Ok((stats.events_sent, stats.events_received))
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,5 +1,6 @@
 mod bench;
 mod compact;
+mod daemon;
 mod info;
 mod keygen;
 mod serve;
@@ -8,6 +9,7 @@ mod sync;
 
 pub use bench::run as bench;
 pub use compact::run as compact;
+pub use daemon::run as daemon;
 pub use info::run as info;
 pub use keygen::run as keygen;
 pub use serve::run as serve;
@@ -21,13 +23,14 @@ pub fn usage() {
   zamsync submit  <data-dir> <payload>
   zamsync sync    <data-dir> <peer-addr> <peer-id> [--tls] [--metrics <addr>]
   zamsync serve   <data-dir> <bind-addr> [--tls] [--metrics <addr>]
+  zamsync daemon  <data-dir> <peer-addr> <peer-id> [--tls] [--interval <secs>] [--metrics <addr>]
   zamsync compact <data-dir>
   zamsync keygen  <data-dir>
   zamsync bench   <data-dir> [--events N]
 
-Flags (serve / sync):
-  --tls            Use mTLS with credentials in <data-dir>/tls/
-                   Run 'zamsync keygen' first to generate credentials.
-  --metrics <addr> Expose Prometheus /metrics on <addr> (e.g. 0.0.0.0:9090)"
+Flags (serve / sync / daemon):
+  --tls              Use mTLS with credentials in <data-dir>/tls/
+  --interval <secs>  Sync interval for daemon mode (default: 60)
+  --metrics <addr>   Expose Prometheus /metrics on <addr> (e.g. 0.0.0.0:9090)"
     );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Some("compact") => cmd::compact(&args),
         Some("keygen")  => cmd::keygen(&args),
         Some("bench")   => cmd::bench(&args),
+        Some("daemon")  => cmd::daemon(&args),
         _ => {
             cmd::usage();
             std::process::exit(1);


### PR DESCRIPTION
## Summary

`zamsync daemon <data-dir> <peer-addr> <peer-id> [--tls] [--interval <secs>] [--metrics <addr>]`

- Syncs with a peer every N seconds (default 60) without external cron
- On error: logs and retries at next tick (no crash)
- Supports `--tls` and `--metrics` like all other commands
- `deploy/zamsync-daemon.service` -- systemd unit for clinic nodes that push to a hub
- `deploy/zamsync.env` updated with `ZAMSYNC_HUB_ADDR`, `ZAMSYNC_HUB_ID`, `ZAMSYNC_INTERVAL`

**Deployment model (Bhutan ePIS):**
- Hub node (Thimphu): runs `zamsync.service` (serve, accepts connections)
- Clinic nodes: run `zamsync-daemon.service` (daemon, pushes every 60s on 2G uptime)

## Test plan

- [ ] `cargo test --workspace` -- 36 tests pass
- [ ] `zamsync serve /tmp/b 0.0.0.0:7001` in one terminal
- [ ] `zamsync daemon /tmp/a 127.0.0.1:7001 <node-b-id> --interval 5` in another -- syncs every 5s