### PR TITLE
feat: WAL encryption at rest (ChaCha20-Poly1305)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +161,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,6 +221,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +252,17 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "typenum",
+]
 
 [[package]]
 name = "deranged"
@@ -300,6 +365,16 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -525,6 +600,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,6 +776,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,6 +808,17 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -811,6 +912,15 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "raw-cpuid"
@@ -1357,6 +1467,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1367,6 +1483,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"
@@ -1787,6 +1913,7 @@ name = "zamsync-storage"
 version = "0.1.0"
 dependencies = [
  "byteorder",
+ "chacha20poly1305",
  "crc32fast",
  "log",
  "metrics",

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -55,9 +55,10 @@
 
 - [x] End-to-end encryption: mutual TLS (mTLS) with rustls (pure Rust, ARM-compatible)
 - [x] Node authentication: certificate-based via shared CA; unauthorized nodes rejected at TLS handshake
-- [x] `zamsync keygen <data-dir>` -- generates CA + node cert pair for a deployment
+- [x] `zamsync keygen <data-dir>` -- generates CA + node cert pair + WAL encryption key (`data.key`)
 - [x] Prometheus metrics: events_submitted, sync duration histogram, events_sent/received, VV drift gauge
 - [x] Docker image + systemd unit for unattended deployment (ARM64/ARMv7 via `docker buildx`)
+- [x] WAL encryption at rest: ChaCha20-Poly1305 AEAD, random nonce per record, `--key-file` flag on all commands
 
 ## First-Deployment Target
 

--- a/crates/zamsync-core/src/event.rs
+++ b/crates/zamsync-core/src/event.rs
@@ -3,6 +3,9 @@ use std::fmt;
 
 pub const WAL_MAGIC: [u8; 4] = [0x5A, 0x41, 0x4D, 0x21];
 pub const WAL_VERSION: u8 = 1;
+/// WAL records with this version byte have their payload encrypted with
+/// ChaCha20-Poly1305. Format: [nonce: 12][ciphertext][tag: 16].
+pub const WAL_VERSION_ENCRYPTED: u8 = 2;
 
 #[derive(
     Archive,

--- a/crates/zamsync-core/src/lib.rs
+++ b/crates/zamsync-core/src/lib.rs
@@ -4,5 +4,5 @@ pub mod ports;
 pub mod sync;
 
 pub use error::{ZamError, ZamResult};
-pub use event::{Chunk, Event, Hlc, NodeId, SequenceNumber, WAL_MAGIC, WAL_VERSION};
+pub use event::{Chunk, Event, Hlc, NodeId, SequenceNumber, WAL_MAGIC, WAL_VERSION, WAL_VERSION_ENCRYPTED};
 pub use sync::{PeerSyncState, ReplicationState, SyncMessage, VersionVector};

--- a/crates/zamsync-storage/Cargo.toml
+++ b/crates/zamsync-storage/Cargo.toml
@@ -8,6 +8,7 @@ description.workspace = true
 
 [dependencies]
 zamsync-core = { path = "../zamsync-core" }
+chacha20poly1305 = "0.10"
 crc32fast.workspace = true
 byteorder.workspace = true
 log.workspace = true

--- a/crates/zamsync-storage/src/adapters/wal_event_store.rs
+++ b/crates/zamsync-storage/src/adapters/wal_event_store.rs
@@ -1,22 +1,32 @@
+use crate::encryption::EncryptionKey;
 use crate::wal::{WalScanner, WalWriter};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use zamsync_core::ports::EventStore;
 use zamsync_core::{Event, SequenceNumber, ZamError, ZamResult};
 
 pub struct WalEventStore {
     path: PathBuf,
     writer: WalWriter,
+    encryption: Option<Arc<EncryptionKey>>,
 }
 
 impl WalEventStore {
     pub fn open(path: impl AsRef<Path>) -> ZamResult<Self> {
-        let (last_seq, end_pos) = WalScanner::recover(&path)?;
+        Self::open_inner(path, None)
+    }
 
-        // Truncate any bytes left past the last valid record. Without this, a
-        // crash mid-write leaves a partial record in the file. WalWriter opens in
-        // APPEND mode, so new records land after the garbage -- and the next scan
-        // stops at the garbage, making those new records permanently invisible.
+    pub fn open_encrypted(path: impl AsRef<Path>, key: EncryptionKey) -> ZamResult<Self> {
+        Self::open_inner(path, Some(Arc::new(key)))
+    }
+
+    fn open_inner(path: impl AsRef<Path>, encryption: Option<Arc<EncryptionKey>>) -> ZamResult<Self> {
+        let (last_seq, end_pos) = match &encryption {
+            Some(key) => WalScanner::recover_encrypted(&path, Arc::clone(key))?,
+            None => WalScanner::recover(&path)?,
+        };
+
         if path.as_ref().exists() {
             let actual_len = std::fs::metadata(path.as_ref())?.len();
             if actual_len > end_pos {
@@ -28,25 +38,20 @@ impl WalEventStore {
         }
 
         let next_seq = last_seq.map(|s| s.next()).unwrap_or(SequenceNumber::ZERO);
-        let writer = WalWriter::open(&path, next_seq)?;
+        let writer = match &encryption {
+            Some(key) => WalWriter::open_encrypted(&path, next_seq, Arc::clone(key))?,
+            None => WalWriter::open(&path, next_seq)?,
+        };
+
         Ok(Self {
             path: path.as_ref().to_path_buf(),
             writer,
+            encryption,
         })
     }
 }
 
 impl WalEventStore {
-    /// Rewrites the WAL, dropping all events whose `seq <= frontier[origin_node]`.
-    /// Events at or below the frontier have been confirmed by all known peers and
-    /// are safe to drop. Original WAL seq numbers are preserved (not renumbered)
-    /// so that the next local-event seq continues correctly after reopening.
-    ///
-    /// If ALL events are dropped, a zero-payload tombstone is written at the
-    /// last seq so that `WalWriter.current_seq` continues from the right position
-    /// instead of resetting to zero.
-    ///
-    /// Returns the number of records dropped. Returns 0 if nothing was dropped.
     pub fn compact(&mut self, frontier: &HashMap<u32, SequenceNumber>) -> ZamResult<usize> {
         if !self.path.exists() || frontier.is_empty() {
             return Ok(0);
@@ -58,11 +63,15 @@ impl WalEventStore {
         let mut dropped = 0usize;
         let mut last_seen_seq: Option<SequenceNumber> = None;
 
-        for result in WalScanner::open(&self.path)?.scan() {
+        let scanner = match &self.encryption {
+            Some(key) => WalScanner::open_encrypted(&self.path, Arc::clone(key))?,
+            None => WalScanner::open(&self.path)?,
+        };
+
+        for result in scanner.scan() {
             let record = result?;
             last_seen_seq = Some(record.seq);
 
-            // Tombstone records (empty payload) are kept to preserve seq continuity.
             if record.payload.is_empty() {
                 kept.push((record.seq, record.payload));
                 continue;
@@ -87,8 +96,6 @@ impl WalEventStore {
             return Ok(0);
         }
 
-        // If every remaining record is a tombstone (or kept is empty), replace them
-        // with a single tombstone at the last WAL seq so WalWriter resumes correctly.
         let all_tombstones = kept.iter().all(|(_, p)| p.is_empty());
         if all_tombstones {
             kept.clear();
@@ -99,20 +106,25 @@ impl WalEventStore {
 
         let tmp = self.path.with_extension("wal.tmp");
         {
-            let mut w = WalWriter::open(&tmp, SequenceNumber::ZERO)?;
+            let mut w = match &self.encryption {
+                Some(key) => WalWriter::open_encrypted(&tmp, SequenceNumber::ZERO, Arc::clone(key))?,
+                None => WalWriter::open(&tmp, SequenceNumber::ZERO)?,
+            };
             for (seq, payload) in &kept {
                 w.append_at_seq(*seq, payload)?;
             }
             w.sync()?;
         }
 
-        // Atomic replace -- on Windows rename fails if the destination exists.
         if self.path.exists() {
             std::fs::remove_file(&self.path)?;
         }
         std::fs::rename(&tmp, &self.path)?;
 
-        let (last_seq, end_pos) = WalScanner::recover(&self.path)?;
+        let (last_seq, end_pos) = match &self.encryption {
+            Some(key) => WalScanner::recover_encrypted(&self.path, Arc::clone(key))?,
+            None => WalScanner::recover(&self.path)?,
+        };
         let next_seq = last_seq.map(|s| s.next()).unwrap_or(SequenceNumber::ZERO);
 
         let actual_len = std::fs::metadata(&self.path).map(|m| m.len()).unwrap_or(0);
@@ -123,7 +135,10 @@ impl WalEventStore {
                 .set_len(end_pos)?;
         }
 
-        self.writer = WalWriter::open(&self.path, next_seq)?;
+        self.writer = match &self.encryption {
+            Some(key) => WalWriter::open_encrypted(&self.path, next_seq, Arc::clone(key))?,
+            None => WalWriter::open(&self.path, next_seq)?,
+        };
         Ok(dropped)
     }
 }
@@ -143,14 +158,17 @@ impl EventStore for WalEventStore {
         if !self.path.exists() {
             return Ok(Box::new(std::iter::empty()));
         }
-        let scanner = WalScanner::open(&self.path)?;
+        let scanner = match &self.encryption {
+            Some(key) => WalScanner::open_encrypted(&self.path, Arc::clone(key))?,
+            None => WalScanner::open(&self.path)?,
+        };
         let iter = scanner.scan().filter_map(|res| -> Option<ZamResult<Event>> {
             let record = match res {
                 Ok(r) => r,
                 Err(e) => return Some(Err(e)),
             };
             if record.payload.is_empty() {
-                return None; // tombstone written by compact() to preserve seq continuity
+                return None;
             }
             Some(
                 rkyv::from_bytes::<Event>(&record.payload)

--- a/crates/zamsync-storage/src/encryption.rs
+++ b/crates/zamsync-storage/src/encryption.rs
@@ -1,0 +1,92 @@
+use chacha20poly1305::{
+    aead::{Aead, AeadCore, KeyInit, OsRng},
+    ChaCha20Poly1305, Nonce,
+};
+use std::path::Path;
+use zamsync_core::{ZamError, ZamResult};
+
+pub const KEY_LEN: usize = 32;
+const NONCE_LEN: usize = 12;
+
+pub struct EncryptionKey {
+    cipher: ChaCha20Poly1305,
+    raw: [u8; KEY_LEN],
+}
+
+impl Clone for EncryptionKey {
+    fn clone(&self) -> Self {
+        Self::from_bytes(self.raw)
+    }
+}
+
+impl EncryptionKey {
+    /// Generate a new random 32-byte key.
+    pub fn generate() -> ZamResult<Self> {
+        let key = ChaCha20Poly1305::generate_key(&mut OsRng);
+        let raw: [u8; KEY_LEN] = key.into();
+        Ok(Self {
+            cipher: ChaCha20Poly1305::new(&key),
+            raw,
+        })
+    }
+
+    pub fn from_bytes(raw: [u8; KEY_LEN]) -> Self {
+        let key = chacha20poly1305::Key::from(raw);
+        Self {
+            cipher: ChaCha20Poly1305::new(&key),
+            raw,
+        }
+    }
+
+    /// Load key from a 32-byte binary file.
+    pub fn from_file(path: impl AsRef<Path>) -> ZamResult<Self> {
+        let bytes = std::fs::read(path.as_ref()).map_err(|e| {
+            ZamError::Io(std::io::Error::new(
+                e.kind(),
+                format!("key file {}: {}", path.as_ref().display(), e),
+            ))
+        })?;
+        if bytes.len() != KEY_LEN {
+            return Err(ZamError::Config(format!(
+                "encryption key must be {KEY_LEN} bytes, got {}",
+                bytes.len()
+            )));
+        }
+        let mut raw = [0u8; KEY_LEN];
+        raw.copy_from_slice(&bytes);
+        Ok(Self::from_bytes(raw))
+    }
+
+    /// Write the raw 32-byte key to a file (permissions should be 0600).
+    pub fn to_file(&self, path: impl AsRef<Path>) -> ZamResult<()> {
+        std::fs::write(path, &self.raw).map_err(Into::into)
+    }
+
+    /// Encrypt `plaintext`. Returns `[nonce: 12][ciphertext][tag: 16]`.
+    pub fn encrypt(&self, plaintext: &[u8]) -> ZamResult<Vec<u8>> {
+        let nonce = ChaCha20Poly1305::generate_nonce(&mut OsRng);
+        let ciphertext = self
+            .cipher
+            .encrypt(&nonce, plaintext)
+            .map_err(|_| ZamError::Config("WAL encryption failed".into()))?;
+        let mut out = Vec::with_capacity(NONCE_LEN + ciphertext.len());
+        out.extend_from_slice(&nonce);
+        out.extend_from_slice(&ciphertext);
+        Ok(out)
+    }
+
+    /// Decrypt `data` (must be `[nonce: 12][ciphertext][tag: 16]`).
+    pub fn decrypt(&self, data: &[u8]) -> ZamResult<Vec<u8>> {
+        if data.len() < NONCE_LEN + 16 {
+            return Err(ZamError::Corruption("encrypted WAL payload too short".into()));
+        }
+        let nonce = Nonce::from_slice(&data[..NONCE_LEN]);
+        self.cipher
+            .decrypt(nonce, &data[NONCE_LEN..])
+            .map_err(|_| {
+                ZamError::Corruption(
+                    "WAL decryption failed -- wrong key or tampered data".into(),
+                )
+            })
+    }
+}

--- a/crates/zamsync-storage/src/engine.rs
+++ b/crates/zamsync-storage/src/engine.rs
@@ -210,6 +210,18 @@ impl<S: StateStore> ZamEngine<WalEventStore, FilePeerStore, S> {
         ZamEngine::new(node_id, event_store, peer_store, state)
     }
 
+    pub fn open_wal_encrypted(
+        data_dir: impl AsRef<Path>,
+        node_id: NodeId,
+        state: S,
+        key: crate::encryption::EncryptionKey,
+    ) -> ZamResult<Self> {
+        let dir = data_dir.as_ref();
+        let event_store = WalEventStore::open_encrypted(dir.join("events.wal"), key)?;
+        let peer_store = FilePeerStore::open(dir.join("peers.state"), node_id)?;
+        ZamEngine::new(node_id, event_store, peer_store, state)
+    }
+
     /// Drops WAL records that ALL known peers have confirmed receiving.
     ///
     /// The compaction frontier is the per-node minimum of `peer.known_vv` across

--- a/crates/zamsync-storage/src/lib.rs
+++ b/crates/zamsync-storage/src/lib.rs
@@ -1,10 +1,12 @@
 pub mod adapters;
+pub mod encryption;
 pub mod engine;
 pub mod sorter;
 pub mod sync_session;
 pub mod wal;
 
 pub use adapters::{FilePeerStore, WalEventStore};
+pub use encryption::EncryptionKey;
 pub use engine::{ZamEngine, EVENTS_PER_BATCH};
 pub use sorter::LogSorter;
 pub use sync_session::{SyncSession, SyncStats};

--- a/crates/zamsync-storage/src/wal.rs
+++ b/crates/zamsync-storage/src/wal.rs
@@ -1,10 +1,12 @@
+use crate::encryption::EncryptionKey;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use crc32fast::Hasher;
 use std::fs::{File, OpenOptions};
 use std::io::{self, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::Path;
+use std::sync::Arc;
 use tracing::warn;
-use zamsync_core::{SequenceNumber, ZamError, ZamResult, WAL_MAGIC, WAL_VERSION};
+use zamsync_core::{SequenceNumber, ZamError, ZamResult, WAL_MAGIC, WAL_VERSION, WAL_VERSION_ENCRYPTED};
 
 /// WAL Header Size: 4 (Magic) + 1 (Ver) + 4 (CRC) + 8 (Seq) + 4 (Len) = 21 bytes.
 pub const WAL_HEADER_SIZE: usize = 21;
@@ -18,17 +20,32 @@ pub struct WalRecord {
 pub struct WalWriter {
     file: BufWriter<File>,
     current_seq: SequenceNumber,
+    encryption: Option<Arc<EncryptionKey>>,
 }
 
 impl WalWriter {
-    /// Opens or creates a WAL file.
-    /// If it exists, it MUST be validated first to ensure no partial records at the end.
     pub fn open(path: impl AsRef<Path>, start_seq: SequenceNumber) -> ZamResult<Self> {
-        let file = OpenOptions::new().create(true).append(true).open(path)?;
+        Self::open_inner(path, start_seq, None)
+    }
 
+    pub fn open_encrypted(
+        path: impl AsRef<Path>,
+        start_seq: SequenceNumber,
+        key: Arc<EncryptionKey>,
+    ) -> ZamResult<Self> {
+        Self::open_inner(path, start_seq, Some(key))
+    }
+
+    fn open_inner(
+        path: impl AsRef<Path>,
+        start_seq: SequenceNumber,
+        encryption: Option<Arc<EncryptionKey>>,
+    ) -> ZamResult<Self> {
+        let file = OpenOptions::new().create(true).append(true).open(path)?;
         Ok(Self {
             file: BufWriter::new(file),
             current_seq: start_seq,
+            encryption,
         })
     }
 
@@ -38,52 +55,31 @@ impl WalWriter {
 
     pub fn append(&mut self, payload: &[u8]) -> ZamResult<SequenceNumber> {
         let seq = self.current_seq;
-        let len = payload.len() as u32;
-
-        // CRC covers: Version + Seq + Len + Payload
-        let mut hasher = Hasher::new();
-        hasher.update(&[WAL_VERSION]);
-        hasher.update(&seq.0.to_be_bytes());
-        hasher.update(&len.to_be_bytes());
-        hasher.update(payload);
-        let crc = hasher.finalize();
-
-        // Write Header
-        self.file.write_all(&WAL_MAGIC)?;
-        self.file.write_u8(WAL_VERSION)?;
-        self.file.write_u32::<BigEndian>(crc)?;
-        self.file.write_u64::<BigEndian>(seq.0)?;
-        self.file.write_u32::<BigEndian>(len)?;
-
-        // Write Payload
-        self.file.write_all(payload)?;
-
-        // Flush to OS. Higher level should call sync() for durability.
-        self.file.flush()?;
-
-        self.current_seq = seq.next();
+        self.append_at_seq(seq, payload)?;
         Ok(seq)
     }
 
-    /// Writes a record at a specific sequence number, advancing `current_seq` if
-    /// necessary. Used during WAL compaction to preserve original seq numbering
-    /// so that the next local-event seq continues from the correct position.
     pub fn append_at_seq(&mut self, seq: SequenceNumber, payload: &[u8]) -> ZamResult<()> {
-        let len = payload.len() as u32;
+        let (version, encoded) = match &self.encryption {
+            Some(key) => (WAL_VERSION_ENCRYPTED, key.encrypt(payload)?),
+            None => (WAL_VERSION, payload.to_vec()),
+        };
+
+        let len = encoded.len() as u32;
 
         let mut hasher = Hasher::new();
-        hasher.update(&[WAL_VERSION]);
+        hasher.update(&[version]);
         hasher.update(&seq.0.to_be_bytes());
         hasher.update(&len.to_be_bytes());
-        hasher.update(payload);
+        hasher.update(&encoded);
         let crc = hasher.finalize();
 
         self.file.write_all(&WAL_MAGIC)?;
-        self.file.write_u8(WAL_VERSION)?;
+        self.file.write_u8(version)?;
         self.file.write_u32::<BigEndian>(crc)?;
         self.file.write_u64::<BigEndian>(seq.0)?;
         self.file.write_u32::<BigEndian>(len)?;
-        self.file.write_all(payload)?;
+        self.file.write_all(&encoded)?;
         self.file.flush()?;
 
         if seq.next() > self.current_seq {
@@ -99,29 +95,53 @@ impl WalWriter {
 
 pub struct WalScanner {
     file: File,
+    encryption: Option<Arc<EncryptionKey>>,
 }
 
 impl WalScanner {
     pub fn open(path: impl AsRef<Path>) -> ZamResult<Self> {
-        let file = File::open(path)?;
-        Ok(Self { file })
+        Self::open_inner(path, None)
     }
 
-    /// Scans the WAL and returns an iterator over valid records.
-    /// It stops at the first corruption or partial write.
+    pub fn open_encrypted(
+        path: impl AsRef<Path>,
+        key: Arc<EncryptionKey>,
+    ) -> ZamResult<Self> {
+        Self::open_inner(path, Some(key))
+    }
+
+    fn open_inner(path: impl AsRef<Path>, encryption: Option<Arc<EncryptionKey>>) -> ZamResult<Self> {
+        let file = File::open(path)?;
+        Ok(Self { file, encryption })
+    }
+
     pub fn scan(self) -> WalIterator {
         WalIterator {
             file: self.file,
             offset: 0,
+            encryption: self.encryption,
         }
     }
 
-    /// Returns the last valid sequence number and the position after it.
     pub fn recover(path: impl AsRef<Path>) -> ZamResult<(Option<SequenceNumber>, u64)> {
+        Self::recover_inner(path, None)
+    }
+
+    pub fn recover_encrypted(
+        path: impl AsRef<Path>,
+        key: Arc<EncryptionKey>,
+    ) -> ZamResult<(Option<SequenceNumber>, u64)> {
+        Self::recover_inner(path, Some(key))
+    }
+
+    fn recover_inner(
+        path: impl AsRef<Path>,
+        encryption: Option<Arc<EncryptionKey>>,
+    ) -> ZamResult<(Option<SequenceNumber>, u64)> {
         if !path.as_ref().exists() {
             return Ok((None, 0));
         }
-        let scanner = WalScanner::open(&path)?;
+        let scanner = Self::open_inner(&path, encryption)?;
         let mut it = scanner.scan();
         let mut last_seq = None;
         let mut last_pos = 0;
@@ -146,7 +166,8 @@ impl WalScanner {
 
 pub struct WalIterator {
     file: File,
-    offset: u64,
+    pub offset: u64,
+    encryption: Option<Arc<EncryptionKey>>,
 }
 
 impl Iterator for WalIterator {
@@ -161,34 +182,29 @@ impl Iterator for WalIterator {
         if bytes_read == 0 {
             return None;
         }
-
         if bytes_read < WAL_HEADER_SIZE {
             return Some(Err(ZamError::Corruption("Partial header at EOF".into())));
         }
 
         let mut rdr = io::Cursor::new(&header);
 
-        // 1. Verify Magic
         let mut magic = [0u8; 4];
         if let Err(e) = rdr.read_exact(&mut magic) {
             return Some(Err(e.into()));
         }
         if magic != WAL_MAGIC {
             return Some(Err(ZamError::Corruption(format!(
-                "Invalid magic: {:?}",
-                magic
+                "Invalid magic: {:?}", magic
             ))));
         }
 
-        // 2. Read Metadata
         let version = match rdr.read_u8() {
             Ok(v) => v,
             Err(e) => return Some(Err(e.into())),
         };
-        if version != WAL_VERSION {
+        if version != WAL_VERSION && version != WAL_VERSION_ENCRYPTED {
             return Some(Err(ZamError::Corruption(format!(
-                "Unsupported version: {}",
-                version
+                "Unsupported WAL version: {}", version
             ))));
         }
 
@@ -206,29 +222,44 @@ impl Iterator for WalIterator {
             Err(e) => return Some(Err(e.into())),
         } as usize;
 
-        // 3. Read Payload
-        let mut payload = vec![0u8; len];
-        if let Err(e) = self.file.read_exact(&mut payload) {
+        let mut raw = vec![0u8; len];
+        if let Err(e) = self.file.read_exact(&mut raw) {
             if e.kind() == io::ErrorKind::UnexpectedEof {
                 return Some(Err(ZamError::Corruption("Partial payload at EOF".into())));
             }
             return Some(Err(e.into()));
         }
 
-        // 4. Verify CRC
+        // Verify CRC (covers encrypted bytes when version == 2)
         let mut hasher = Hasher::new();
         hasher.update(&[version]);
         hasher.update(&seq.0.to_be_bytes());
         hasher.update(&(len as u32).to_be_bytes());
-        hasher.update(&payload);
+        hasher.update(&raw);
         let actual_crc = hasher.finalize();
-
         if actual_crc != expected_crc {
             return Some(Err(ZamError::Corruption(format!(
-                "CRC mismatch for sequence {}: expected {}, got {}",
+                "CRC mismatch for seq {}: expected {}, got {}",
                 seq, expected_crc, actual_crc
             ))));
         }
+
+        // Decrypt if needed
+        let payload = if version == WAL_VERSION_ENCRYPTED {
+            match &self.encryption {
+                Some(key) => match key.decrypt(&raw) {
+                    Ok(p) => p,
+                    Err(e) => return Some(Err(e)),
+                },
+                None => {
+                    return Some(Err(ZamError::Config(
+                        "WAL is encrypted but no key was provided -- use --key-file".into(),
+                    )))
+                }
+            }
+        } else {
+            raw
+        };
 
         self.offset += (WAL_HEADER_SIZE + len) as u64;
         Some(Ok(WalRecord { seq, payload }))
@@ -265,6 +296,34 @@ mod tests {
     }
 
     #[test]
+    fn test_wal_encrypted_roundtrip() -> ZamResult<()> {
+        let dir = tempdir()?;
+        let path = dir.path().join("enc.wal");
+        let key = Arc::new(EncryptionKey::generate()?);
+
+        let mut writer = WalWriter::open_encrypted(&path, SequenceNumber::ZERO, Arc::clone(&key))?;
+        writer.append(b"patient-data-secret")?;
+        writer.append(b"another-record")?;
+        writer.sync()?;
+
+        // Reading WITHOUT key must fail
+        let scanner = WalScanner::open(&path)?;
+        let err = scanner.scan().next().unwrap().unwrap_err();
+        assert!(
+            matches!(err, ZamError::Config(_)),
+            "expected Config error, got {err:?}"
+        );
+
+        // Reading WITH key must succeed
+        let scanner = WalScanner::open_encrypted(&path, Arc::clone(&key))?;
+        let mut it = scanner.scan();
+        assert_eq!(it.next().unwrap().unwrap().payload, b"patient-data-secret");
+        assert_eq!(it.next().unwrap().unwrap().payload, b"another-record");
+        assert!(it.next().is_none());
+        Ok(())
+    }
+
+    #[test]
     fn test_wal_recovery_partial_write() -> ZamResult<()> {
         let dir = tempdir()?;
         let path = dir.path().join("test.wal");
@@ -275,20 +334,16 @@ mod tests {
             writer.sync()?;
         }
 
-        // Manually append garbage (partial header)
         {
             let mut f = OpenOptions::new().append(true).open(&path)?;
             f.write_all(&WAL_MAGIC)?;
             f.write_all(&[WAL_VERSION])?;
-            // Missing CRC, Seq, Len, Payload
         }
 
         let (last_seq, pos) = WalScanner::recover(&path)?;
         assert_eq!(last_seq, Some(SequenceNumber(0)));
-        // Position should be exactly after the first record
         let first_record_size = WAL_HEADER_SIZE + 5;
         assert_eq!(pos, first_record_size as u64);
-
         Ok(())
     }
 
@@ -301,22 +356,18 @@ mod tests {
         writer.append(b"perfect")?;
         writer.sync()?;
 
-        // Corrupt the payload
         {
             let mut f = OpenOptions::new().write(true).open(&path)?;
             f.seek(SeekFrom::Start((WAL_HEADER_SIZE + 1) as u64))?;
-            f.write_all(b"x")?; // Change 'p' to 'x'
+            f.write_all(b"x")?;
         }
 
         let scanner = WalScanner::open(&path)?;
         let mut it = scanner.scan();
-        let res = it.next().unwrap();
-
-        match res {
+        match it.next().unwrap() {
             Err(ZamError::Corruption(msg)) => assert!(msg.contains("CRC mismatch")),
-            _ => panic!("Expected CRC mismatch error, got {:?}", res),
+            other => panic!("Expected CRC mismatch error, got {:?}", other),
         }
-
         Ok(())
     }
 }

--- a/src/cmd/daemon.rs
+++ b/src/cmd/daemon.rs
@@ -1,9 +1,9 @@
 use crate::metrics::start_metrics_server;
-use crate::util::{data_dir, flag_value, load_tls_config, node_id_from_dir, EventCounter};
+use crate::util::{data_dir, flag_value, load_encryption_key, load_tls_config, node_id_from_dir, EventCounter};
 use std::time::{Duration, Instant};
 use zamsync_core::NodeId;
 use zamsync_network::{TcpTransport, TlsTcpTransport};
-use zamsync_storage::{SyncSession, ZamEngine};
+use zamsync_storage::{EncryptionKey, SyncSession, ZamEngine};
 
 pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     let dir = data_dir(args, 2)?;
@@ -13,6 +13,7 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
         .and_then(|v| v.parse().ok())
         .unwrap_or(60);
     let use_tls = args.contains(&"--tls".to_string());
+    let enc_key = load_encryption_key(args)?;
 
     if let Some(metrics_addr) = flag_value(args, "--metrics") {
         start_metrics_server(metrics_addr)?;
@@ -30,7 +31,7 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
 
     loop {
         let tick_start = Instant::now();
-        match sync_once(&dir, node_id, peer, peer_addr, use_tls) {
+        match sync_once(&dir, node_id, peer, peer_addr, use_tls, enc_key.as_ref()) {
             Ok((sent, received)) => {
                 if sent > 0 || received > 0 {
                     println!(
@@ -44,7 +45,6 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
             Err(e) => eprintln!("[sync] peer={} error: {}", peer_id, e),
         }
 
-        // Sleep for the remainder of the interval, regardless of how long sync took.
         let elapsed = tick_start.elapsed();
         if elapsed < interval {
             std::thread::sleep(interval - elapsed);
@@ -58,8 +58,12 @@ fn sync_once(
     peer: NodeId,
     peer_addr: &str,
     use_tls: bool,
+    enc_key: Option<&EncryptionKey>,
 ) -> Result<(usize, usize), Box<dyn std::error::Error>> {
-    let mut engine = ZamEngine::open_wal(dir, node_id, EventCounter::default())?;
+    let mut engine = match enc_key {
+        Some(key) => ZamEngine::open_wal_encrypted(dir, node_id, EventCounter::default(), key.clone())?,
+        None => ZamEngine::open_wal(dir, node_id, EventCounter::default())?,
+    };
 
     let stats = if use_tls {
         let tls_config = load_tls_config(dir)?;

--- a/src/cmd/keygen.rs
+++ b/src/cmd/keygen.rs
@@ -1,24 +1,36 @@
 use crate::util::data_dir;
 use zamsync_network::generate_credentials;
+use zamsync_storage::EncryptionKey;
 
 pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     let dir = data_dir(args, 2)?;
     let tls_dir = dir.join("tls");
     std::fs::create_dir_all(&tls_dir)?;
 
+    // TLS credentials (mTLS transport)
     let creds = generate_credentials()?;
     std::fs::write(tls_dir.join("ca.crt"), &creds.ca_cert_pem)?;
     std::fs::write(tls_dir.join("ca.key"), &creds.ca_key_pem)?;
     std::fs::write(tls_dir.join("node.crt"), &creds.node_cert_pem)?;
     std::fs::write(tls_dir.join("node.key"), &creds.node_key_pem)?;
 
-    println!("TLS credentials generated in {}/tls/", dir.display());
+    // WAL encryption key (at-rest protection)
+    let enc_key = EncryptionKey::generate()?;
+    enc_key.to_file(tls_dir.join("data.key"))?;
+
+    println!("Credentials generated in {}/tls/", dir.display());
     println!();
+    println!("  === TLS (transport encryption) ===");
     println!("  ca.crt   -- copy to all other nodes in this deployment");
     println!("  ca.key   -- keep secret; only needed to sign new node certs");
     println!("  node.crt -- this node's identity certificate");
     println!("  node.key -- this node's private key (never share)");
     println!();
-    println!("Use '--tls' with 'serve' and 'sync' to enable encrypted transport.");
+    println!("  === WAL encryption (at-rest) ===");
+    println!("  data.key -- 32-byte random key for WAL encryption");
+    println!("              CRITICAL: store outside the data dir in production");
+    println!("              Recommended: move to /etc/zamsync/data.key (chmod 600)");
+    println!();
+    println!("Use '--tls' to encrypt transport, '--key-file <path>' to encrypt WAL.");
     Ok(())
 }

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -1,14 +1,17 @@
 use crate::metrics::start_metrics_server;
-use crate::util::{data_dir, flag_value, load_tls_config, node_id_from_dir, EventCounter};
+use crate::util::{data_dir, flag_value, load_encryption_key, load_tls_config, node_id_from_dir, EventCounter};
 use std::path::Path;
 use zamsync_core::NodeId;
 use zamsync_network::{TcpTransport, TlsTcpTransport};
-use zamsync_storage::{SyncSession, ZamEngine};
+use zamsync_storage::{EncryptionKey, FilePeerStore, SyncSession, WalEventStore, ZamEngine};
+
+type Engine = ZamEngine<WalEventStore, FilePeerStore, EventCounter>;
 
 pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     let dir = data_dir(args, 2)?;
     let bind_addr = args.get(3).ok_or("missing bind-addr")?;
     let use_tls = args.contains(&"--tls".to_string());
+    let enc_key = load_encryption_key(args)?;
 
     if let Some(metrics_addr) = flag_value(args, "--metrics") {
         start_metrics_server(metrics_addr)?;
@@ -20,18 +23,25 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
         let tls_config = load_tls_config(&dir)?;
         let mut transport = TlsTcpTransport::bind(bind_addr, &tls_config)?;
         println!("node {} TLS listening on {}", node_id.0, transport.local_addr()?);
-        tls_loop(node_id, &dir, &mut transport);
+        tls_loop(node_id, &dir, enc_key, &mut transport);
     } else {
         let mut transport = TcpTransport::bind(bind_addr)?;
         println!("node {} listening on {}", node_id.0, transport.local_addr()?);
-        tcp_loop(node_id, &dir, &mut transport);
+        tcp_loop(node_id, &dir, enc_key, &mut transport);
     }
     Ok(())
 }
 
-fn tcp_loop(node_id: NodeId, dir: &Path, transport: &mut TcpTransport) {
+fn open_engine(dir: &Path, node_id: NodeId, enc_key: &Option<EncryptionKey>) -> zamsync_core::ZamResult<Engine> {
+    match enc_key {
+        Some(key) => ZamEngine::open_wal_encrypted(dir, node_id, EventCounter::default(), key.clone()),
+        None => ZamEngine::open_wal(dir, node_id, EventCounter::default()),
+    }
+}
+
+fn tcp_loop(node_id: NodeId, dir: &Path, enc_key: Option<EncryptionKey>, transport: &mut TcpTransport) {
     loop {
-        let mut engine = match ZamEngine::open_wal(dir, node_id, EventCounter::default()) {
+        let mut engine = match open_engine(dir, node_id, &enc_key) {
             Ok(e) => e,
             Err(e) => {
                 eprintln!("engine open error: {e}");
@@ -57,9 +67,9 @@ fn tcp_loop(node_id: NodeId, dir: &Path, transport: &mut TcpTransport) {
     }
 }
 
-fn tls_loop(node_id: NodeId, dir: &Path, transport: &mut TlsTcpTransport) {
+fn tls_loop(node_id: NodeId, dir: &Path, enc_key: Option<EncryptionKey>, transport: &mut TlsTcpTransport) {
     loop {
-        let mut engine = match ZamEngine::open_wal(dir, node_id, EventCounter::default()) {
+        let mut engine = match open_engine(dir, node_id, &enc_key) {
             Ok(e) => e,
             Err(e) => {
                 eprintln!("engine open error: {e}");

--- a/src/cmd/submit.rs
+++ b/src/cmd/submit.rs
@@ -1,11 +1,15 @@
-use crate::util::{data_dir, node_id_from_dir, EventCounter};
+use crate::util::{data_dir, load_encryption_key, node_id_from_dir, EventCounter};
 use zamsync_storage::ZamEngine;
 
 pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     let dir = data_dir(args, 2)?;
     let payload = args.get(3).ok_or("missing payload")?.as_bytes().to_vec();
+    let enc_key = load_encryption_key(args)?;
     let node_id = node_id_from_dir(&dir);
-    let mut engine = ZamEngine::open_wal(&dir, node_id, EventCounter::default())?;
+    let mut engine = match enc_key {
+        Some(key) => ZamEngine::open_wal_encrypted(&dir, node_id, EventCounter::default(), key)?,
+        None => ZamEngine::open_wal(&dir, node_id, EventCounter::default())?,
+    };
     let seq = engine.submit(1, payload)?;
     engine.sync()?;
     println!("submitted seq={}", seq.0);

--- a/src/cmd/sync.rs
+++ b/src/cmd/sync.rs
@@ -1,5 +1,5 @@
 use crate::metrics::start_metrics_server;
-use crate::util::{data_dir, flag_value, is_transient, load_tls_config, node_id_from_dir, EventCounter};
+use crate::util::{data_dir, flag_value, is_transient, load_encryption_key, load_tls_config, node_id_from_dir, EventCounter};
 use zamsync_core::NodeId;
 use zamsync_network::{TcpTransport, TlsTcpTransport};
 use zamsync_storage::{SyncSession, ZamEngine};
@@ -9,13 +9,17 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     let peer_addr = args.get(3).ok_or("missing peer-addr")?;
     let peer_id: u32 = args.get(4).ok_or("missing peer-id")?.parse()?;
     let use_tls = args.contains(&"--tls".to_string());
+    let enc_key = load_encryption_key(args)?;
 
     if let Some(metrics_addr) = flag_value(args, "--metrics") {
         start_metrics_server(metrics_addr)?;
     }
 
     let node_id = node_id_from_dir(&dir);
-    let mut engine = ZamEngine::open_wal(&dir, node_id, EventCounter::default())?;
+    let mut engine = match enc_key {
+        Some(key) => ZamEngine::open_wal_encrypted(&dir, node_id, EventCounter::default(), key)?,
+        None => ZamEngine::open_wal(&dir, node_id, EventCounter::default())?,
+    };
     let peer = NodeId(peer_id);
 
     const MAX_ATTEMPTS: u32 = 5;

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use zamsync_core::ports::StateStore;
 use zamsync_core::{Event, NodeId, SequenceNumber, ZamResult};
 use zamsync_network::TlsConfig;
+use zamsync_storage::EncryptionKey;
 
 #[derive(Default)]
 pub struct EventCounter {
@@ -67,6 +68,13 @@ pub fn load_tls_config(dir: &Path) -> Result<TlsConfig, Box<dyn std::error::Erro
         tls_dir.join("node.key"),
         tls_dir.join("ca.crt"),
     )?)
+}
+
+pub fn load_encryption_key(args: &[String]) -> Result<Option<EncryptionKey>, Box<dyn std::error::Error>> {
+    match flag_value(args, "--key-file") {
+        Some(path) => Ok(Some(EncryptionKey::from_file(path)?)),
+        None => Ok(None),
+    }
 }
 
 fn rand_u32() -> u32 {


### PR DESCRIPTION
## Summary

- **`EncryptionKey`** -- ChaCha20-Poly1305 AEAD wrapper with `generate`, `from_file`, `to_file`, `encrypt`, `decrypt`, and `Clone`
- **WAL v2** -- version byte `2` signals encrypted records; each record stores `[nonce:12][ciphertext][tag:16]`; version `1` (plain) is fully backward compatible
- **`WalWriter` / `WalScanner`** -- `open_encrypted` variants thread the key through write and read paths; scanner returns `ZamError::Config` on missing key for v2 WAL
- **`WalEventStore` / `ZamEngine`** -- `open_encrypted` constructors; `compact()` preserves encryption on the rewritten WAL
- **`zamsync keygen`** -- now also generates `data.key` (32 random bytes) alongside TLS certs with advice to move it to `/etc/zamsync/data.key`
- **CLI** -- `--key-file ` flag wired into `serve`, `sync`, `daemon`, and `submit`

## Security properties

- Key never stored in the WAL -- must be provided at startup
- Random nonce per record -- no nonce reuse even with same key
- CRC covers the encrypted bytes -- detects both corruption and truncation before decryption
- Plain WAL (no `--key-file`) continues to work unchanged -- opt-in per deployment

## Test plan

- [x] `cargo test --workspace` -- 38 tests pass including `test_wal_encrypted_roundtrip` (write encrypted, read without key fails, read with key succeeds)
- [x] `cargo check --workspace` -- zero warnings
- [ ] Deploy to Bhutan ePIS staging: run `zamsync keygen`, move `data.key` to `/etc/zamsync/`, start daemon with `--key-file /etc/zamsync/data.key`