### PR TITLE
feat: automated multi-platform release infrastructure

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,206 @@
+name: Build Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # ── Compile binaries ─────────────────────────────────────────────────────────
+  build:
+    name: Build (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            use_cross: false
+            artifact: zamsync-linux-x86_64
+            binary: zamsync
+
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            use_cross: true
+            artifact: zamsync-linux-aarch64
+            binary: zamsync
+
+          - target: armv7-unknown-linux-gnueabihf
+            os: ubuntu-latest
+            use_cross: true
+            artifact: zamsync-linux-armv7
+            binary: zamsync
+
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            use_cross: false
+            artifact: zamsync-windows-x86_64
+            binary: zamsync.exe
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: release-${{ matrix.target }}
+
+      - name: Install cross
+        if: matrix.use_cross
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+
+      - name: Build (native)
+        if: "!matrix.use_cross"
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Build (cross)
+        if: matrix.use_cross
+        run: cross build --release --target ${{ matrix.target }}
+
+      - name: Stage artifact
+        shell: bash
+        run: |
+          mkdir -p dist
+          src="target/${{ matrix.target }}/release/${{ matrix.binary }}"
+          dst="dist/${{ matrix.artifact }}"
+          cp "$src" "$dst"
+          # Windows binary keeps .exe suffix
+          if [[ "${{ matrix.target }}" == *windows* ]]; then
+            mv "$dst" "${dst}.exe"
+          fi
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: dist/
+          if-no-files-found: error
+
+  # ── Docker multi-arch image on GHCR ─────────────────────────────────────────
+  docker:
+    name: Docker (ghcr.io)
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist/
+
+      - name: Prepare build context
+        run: |
+          mkdir -p docker-ctx
+          cp dist/zamsync-linux-x86_64/zamsync-linux-x86_64   docker-ctx/zamsync-linux-amd64
+          cp dist/zamsync-linux-aarch64/zamsync-linux-aarch64 docker-ctx/zamsync-linux-arm64
+          cp dist/zamsync-linux-armv7/zamsync-linux-armv7     docker-ctx/zamsync-linux-armv7
+          chmod +x docker-ctx/*
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: docker-ctx
+          file: Dockerfile.release
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  # ── GitHub Release with checksums ────────────────────────────────────────────
+  github-release:
+    name: GitHub Release
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist/
+
+      - name: Collect binaries and generate checksums
+        run: |
+          mkdir -p release
+          cp dist/zamsync-linux-x86_64/zamsync-linux-x86_64     release/
+          cp dist/zamsync-linux-aarch64/zamsync-linux-aarch64   release/
+          cp dist/zamsync-linux-armv7/zamsync-linux-armv7       release/
+          cp dist/zamsync-windows-x86_64/zamsync-windows-x86_64.exe release/
+          cd release
+          sha256sum * > SHA256SUMS.txt
+          cat SHA256SUMS.txt
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          name: "ZamSync ${{ github.ref_name }}"
+          body: |
+            ## ZamSync ${{ github.ref_name }}
+
+            Offline-first synchronization engine for intermittent-connectivity deployments.
+
+            ### Install
+
+            ```bash
+            # Linux x86_64
+            curl -fsSL -o zamsync https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/zamsync-linux-x86_64
+            chmod +x zamsync && sudo mv zamsync /usr/local/bin/
+
+            # Linux ARM64 (Raspberry Pi 4, AWS Graviton)
+            curl -fsSL -o zamsync https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/zamsync-linux-aarch64
+            chmod +x zamsync && sudo mv zamsync /usr/local/bin/
+
+            # Linux ARMv7 (Raspberry Pi 2 / 3)
+            curl -fsSL -o zamsync https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/zamsync-linux-armv7
+            chmod +x zamsync && sudo mv zamsync /usr/local/bin/
+
+            # Windows (PowerShell)
+            Invoke-WebRequest -Uri "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/zamsync-windows-x86_64.exe" -OutFile zamsync.exe
+            ```
+
+            ### Docker
+
+            ```bash
+            docker pull ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+            # or latest
+            docker pull ghcr.io/${{ github.repository }}:latest
+            ```
+
+            ### Verify checksums
+
+            ```bash
+            sha256sum -c SHA256SUMS.txt
+            ```
+          files: |
+            release/*
+          generate_release_notes: true
+          fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release -- e.g. 1.0.0 (no v prefix)'
+        required: true
+        type: string
+
+jobs:
+  prepare:
+    name: Bump version and tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Use GITHUB_TOKEN with write access.
+          # If branch protection requires PR reviews, add an exception for
+          # github-actions[bot] in Settings -> Branches -> bypass list.
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate version format
+        run: |
+          if ! echo "${{ inputs.version }}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Bad version '${{ inputs.version }}' -- must be MAJOR.MINOR.PATCH"
+            exit 1
+          fi
+
+      - name: Bump version in Cargo.toml
+        run: |
+          sed -i -E 's/^version = "[0-9]+\.[0-9]+\.[0-9]+"$/version = "${{ inputs.version }}"/' Cargo.toml
+          # Verify the replacement landed
+          grep -E '^version = "${{ inputs.version }}"' Cargo.toml || {
+            echo "::error::Version replacement failed"
+            exit 1
+          }
+
+      - name: Commit and push
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Cargo.toml
+          git commit -m "chore: release v${{ inputs.version }}"
+          git push
+
+      - name: Create and push tag
+        run: |
+          git tag "v${{ inputs.version }}"
+          git push origin "v${{ inputs.version }}"
+          echo "Tagged v${{ inputs.version }} -- build-release.yml will now run"

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,50 @@
+# syntax=docker/dockerfile:1
+#
+# Release image: copies a pre-built binary instead of compiling from source.
+# Produced by .github/workflows/build-release.yml.
+#
+# Build context (docker-ctx/) must contain:
+#   zamsync-linux-amd64   -- linux/amd64  binary (built natively)
+#   zamsync-linux-arm64   -- linux/arm64  binary (built via cross)
+#   zamsync-linux-armv7   -- linux/arm/v7 binary (built via cross)
+#
+# The selector stage runs on the BUILD host (no QEMU needed for selection).
+# Only the final apt-get install step uses QEMU -- it takes seconds, not minutes.
+
+# ── Stage 1: select the right binary (runs on build host, no QEMU) ───────────
+FROM --platform=$BUILDPLATFORM debian:bookworm-slim AS selector
+
+ARG TARGETPLATFORM
+
+COPY zamsync-linux-amd64 /tmp/bins/zamsync-linux-amd64
+COPY zamsync-linux-arm64 /tmp/bins/zamsync-linux-arm64
+COPY zamsync-linux-armv7 /tmp/bins/zamsync-linux-armv7
+
+RUN case "$TARGETPLATFORM" in \
+      "linux/amd64")  cp /tmp/bins/zamsync-linux-amd64 /usr/local/bin/zamsync ;; \
+      "linux/arm64")  cp /tmp/bins/zamsync-linux-arm64  /usr/local/bin/zamsync ;; \
+      "linux/arm/v7") cp /tmp/bins/zamsync-linux-armv7  /usr/local/bin/zamsync ;; \
+      *) echo "Unsupported platform: $TARGETPLATFORM" && exit 1 ;; \
+    esac && \
+    chmod +x /usr/local/bin/zamsync
+
+# ── Stage 2: minimal runtime image ───────────────────────────────────────────
+FROM --platform=$TARGETPLATFORM debian:bookworm-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/* && \
+    groupadd -r -g 1000 zamsync && \
+    useradd  -r -u 1000 -g zamsync -s /bin/false -d /var/lib/zamsync zamsync && \
+    mkdir -p /var/lib/zamsync && \
+    chown zamsync:zamsync /var/lib/zamsync
+
+COPY --from=selector /usr/local/bin/zamsync /usr/local/bin/zamsync
+
+USER zamsync
+
+VOLUME /var/lib/zamsync
+EXPOSE 7000
+
+ENTRYPOINT ["/usr/local/bin/zamsync"]
+CMD ["serve", "/var/lib/zamsync", "0.0.0.0:7000"]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -114,7 +114,10 @@
 
 ### Intégration CI/CD
 
-- [ ] Image Docker officielle publiée sur GHCR avec tags `latest`, `arm64`, `armv7`
+- [x] Release automatisée : `workflow_dispatch` avec saisie de version → bump `Cargo.toml` + commit + tag → `build-release.yml` déclenché
+- [x] Binaires multi-plateformes : x86_64-linux, aarch64-linux, armv7-linux, x86_64-windows -- compilés nativement ou via `cross`
+- [x] Image Docker multi-arch publiée sur GHCR : `latest`, `1.x`, `1.x.y` -- sans QEMU pour la compilation (binaires pré-construits via `Dockerfile.release`)
+- [x] GitHub Release avec checksums SHA-256 et notes de version automatiques
 - [ ] Helm chart pour déploiement Kubernetes (hub en Deployment, nœuds en DaemonSet)
 - [ ] GitHub Actions réutilisable : `uses: zamsync/actions/deploy-hub@v1`
 


### PR DESCRIPTION
## Summary

Fully automated release pipeline -- no manual `git tag` needed, ever.

Inspired by TursoDB and similar projects: a human triggers the release from the GitHub UI, everything else is automated.

### How to ship a release

1. Go to **Actions → Release → Run workflow**
2. Enter the version number (e.g. `1.0.0`)
3. Click **Run workflow**

That's it. The rest is automatic:

```
release.yml (workflow_dispatch)
  └── bumps Cargo.toml version
  └── commits "chore: release v1.0.0" to main
  └── creates and pushes tag v1.0.0
        │
        ▼
build-release.yml (push: tags: v*)
  ├── build matrix (4 targets in parallel)
  │     x86_64-linux   → native cargo build
  │     aarch64-linux  → cross (pre-built binary, no QEMU)
  │     armv7-linux    → cross (pre-built binary, no QEMU)
  │     x86_64-windows → native cargo build on windows-latest
  │
  ├── GitHub Release
  │     binaries + SHA-256 checksums + auto-generated release notes
  │
  └── Docker multi-arch (ghcr.io)
        linux/amd64, linux/arm64, linux/arm/v7
        tags: 1.0.0 / 1.0 / latest
```

### Files

| File | Purpose |
|---|---|
| `.github/workflows/release.yml` | `workflow_dispatch` entry point -- version bump + tag |
| `.github/workflows/build-release.yml` | Build matrix + Docker + GitHub Release |
| `Dockerfile.release` | Thin runtime image with pre-built binary (no QEMU for Rust compilation) |

### Docker approach

`Dockerfile.release` uses a `--platform=$BUILDPLATFORM` selector stage that picks the right pre-built binary without QEMU. Only the final `apt-get install ca-certificates` runs under emulation (takes seconds, not the 30 minutes of QEMU-compiled Rust).

## Test plan

- [ ] Merge to main
- [ ] Actions → Release → Run workflow → version `1.0.0`
- [ ] Verify commit and tag appear on main
- [ ] Verify build-release.yml triggers automatically
- [ ] Verify 4 binaries in GitHub Release + SHA256SUMS.txt
- [ ] Verify `ghcr.io/Etoile-Bleu/ZamSync:latest` pulls on amd64 and arm64

🤖 Generated with [Claude Code](https://claude.com/claude-code)