### PR TITLE
fix: build-release.yml not triggered by GITHUB_TOKEN tag push

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -4,9 +4,25 @@ on:
   push:
     tags:
       - 'v*'
+  # Called explicitly by release.yml after pushing the tag.
+  # GITHUB_TOKEN cannot trigger cross-workflow events (GitHub security policy),
+  # so release.yml dispatches us with --ref "vX.Y.Z" on the tag ref.
+  #
+  # Also accepts an optional `version` input for manual rescue runs from main
+  # (e.g. gh workflow run build-release.yml -f version=v1.0.0).
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Tag to release, e.g. v1.0.0 (leave empty when run on a tag ref)'
+        required: false
+        type: string
 
 env:
   CARGO_TERM_COLOR: always
+  # Resolved once here, used everywhere.
+  # - tag push or dispatch --ref "vX.Y.Z" : github.ref_name = vX.Y.Z, inputs.version = ''
+  # - manual dispatch from main with version input : github.ref_name = main, inputs.version = vX.Y.Z
+  RELEASE_TAG: ${{ inputs.version != '' && inputs.version || github.ref_name }}
 
 jobs:
   # ── Compile binaries ─────────────────────────────────────────────────────────
@@ -43,6 +59,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -73,7 +91,6 @@ jobs:
           src="target/${{ matrix.target }}/release/${{ matrix.binary }}"
           dst="dist/${{ matrix.artifact }}"
           cp "$src" "$dst"
-          # Windows binary keeps .exe suffix
           if [[ "${{ matrix.target }}" == *windows* ]]; then
             mv "$dst" "${dst}.exe"
           fi
@@ -95,6 +112,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - uses: actions/download-artifact@v4
         with:
@@ -108,6 +127,15 @@ jobs:
           cp dist/zamsync-linux-armv7/zamsync-linux-armv7     docker-ctx/zamsync-linux-armv7
           chmod +x docker-ctx/*
 
+      - name: Compute Docker tags
+        id: tags
+        run: |
+          tag="${{ env.RELEASE_TAG }}"
+          ver="${tag#v}"                                  # strip leading v
+          major_minor="$(echo "$ver" | cut -d. -f1-2)"  # e.g. 1.0
+          repo="ghcr.io/${{ github.repository }}"
+          echo "value=${repo}:${ver},${repo}:${major_minor},${repo}:latest" >> $GITHUB_OUTPUT
+
       - uses: docker/setup-qemu-action@v3
 
       - uses: docker/setup-buildx-action@v3
@@ -118,23 +146,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/metadata-action@v5
-        id: meta
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest
-
       - uses: docker/build-push-action@v6
         with:
           context: docker-ctx
           file: Dockerfile.release
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.tags.outputs.value }}
 
   # ── GitHub Release with checksums ────────────────────────────────────────────
   github-release:
@@ -152,9 +170,9 @@ jobs:
       - name: Collect binaries and generate checksums
         run: |
           mkdir -p release
-          cp dist/zamsync-linux-x86_64/zamsync-linux-x86_64     release/
-          cp dist/zamsync-linux-aarch64/zamsync-linux-aarch64   release/
-          cp dist/zamsync-linux-armv7/zamsync-linux-armv7       release/
+          cp dist/zamsync-linux-x86_64/zamsync-linux-x86_64       release/
+          cp dist/zamsync-linux-aarch64/zamsync-linux-aarch64     release/
+          cp dist/zamsync-linux-armv7/zamsync-linux-armv7         release/
           cp dist/zamsync-windows-x86_64/zamsync-windows-x86_64.exe release/
           cd release
           sha256sum * > SHA256SUMS.txt
@@ -162,9 +180,10 @@ jobs:
 
       - uses: softprops/action-gh-release@v2
         with:
-          name: "ZamSync ${{ github.ref_name }}"
+          tag_name: ${{ env.RELEASE_TAG }}
+          name: "ZamSync ${{ env.RELEASE_TAG }}"
           body: |
-            ## ZamSync ${{ github.ref_name }}
+            ## ZamSync ${{ env.RELEASE_TAG }}
 
             Offline-first synchronization engine for intermittent-connectivity deployments.
 
@@ -172,25 +191,25 @@ jobs:
 
             ```bash
             # Linux x86_64
-            curl -fsSL -o zamsync https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/zamsync-linux-x86_64
+            curl -fsSL -o zamsync https://github.com/${{ github.repository }}/releases/download/${{ env.RELEASE_TAG }}/zamsync-linux-x86_64
             chmod +x zamsync && sudo mv zamsync /usr/local/bin/
 
             # Linux ARM64 (Raspberry Pi 4, AWS Graviton)
-            curl -fsSL -o zamsync https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/zamsync-linux-aarch64
+            curl -fsSL -o zamsync https://github.com/${{ github.repository }}/releases/download/${{ env.RELEASE_TAG }}/zamsync-linux-aarch64
             chmod +x zamsync && sudo mv zamsync /usr/local/bin/
 
             # Linux ARMv7 (Raspberry Pi 2 / 3)
-            curl -fsSL -o zamsync https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/zamsync-linux-armv7
+            curl -fsSL -o zamsync https://github.com/${{ github.repository }}/releases/download/${{ env.RELEASE_TAG }}/zamsync-linux-armv7
             chmod +x zamsync && sudo mv zamsync /usr/local/bin/
 
             # Windows (PowerShell)
-            Invoke-WebRequest -Uri "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/zamsync-windows-x86_64.exe" -OutFile zamsync.exe
+            Invoke-WebRequest -Uri "https://github.com/${{ github.repository }}/releases/download/${{ env.RELEASE_TAG }}/zamsync-windows-x86_64.exe" -OutFile zamsync.exe
             ```
 
             ### Docker
 
             ```bash
-            docker pull ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+            docker pull ghcr.io/${{ github.repository }}:${{ env.RELEASE_TAG }}
             # or latest
             docker pull ghcr.io/${{ github.repository }}:latest
             ```

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # Use GITHUB_TOKEN with write access.
-          # If branch protection requires PR reviews, add an exception for
-          # github-actions[bot] in Settings -> Branches -> bypass list.
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Validate version format
@@ -51,4 +48,10 @@ jobs:
         run: |
           git tag "v${{ inputs.version }}"
           git push origin "v${{ inputs.version }}"
-          echo "Tagged v${{ inputs.version }} -- build-release.yml will now run"
+
+      - name: Trigger build-release.yml on tag
+        run: |
+          gh workflow run build-release.yml --ref "v${{ inputs.version }}"
+          echo "Dispatched build-release.yml on v${{ inputs.version }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Root cause

GitHub blocks cross-workflow event triggers from `GITHUB_TOKEN` to prevent infinite loops. The `release.yml` pushed the tag using `GITHUB_TOKEN`, so `build-release.yml` never fired -- only the tag was created.

## Fix

`release.yml` now explicitly dispatches `build-release.yml` after pushing the tag:

```yaml
- name: Trigger build-release.yml on tag
  run: gh workflow run build-release.yml --ref "v${{ inputs.version }}"
  env:
    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

`build-release.yml` gets a `workflow_dispatch` trigger so it can receive the dispatch. A `RELEASE_TAG` env var is computed once at workflow level and used everywhere (handles both the tag-push path and the dispatch path):

```yaml
env:
  RELEASE_TAG: ${{ inputs.version != '' && inputs.version || github.ref_name }}
```

## Rescue v1.0.0 without re-tagging

After merging this PR, trigger the build for the existing v1.0.0 tag from the Actions tab:

```bash
gh workflow run build-release.yml -f version=v1.0.0
```

Or via GitHub UI: **Actions -> Build Release -> Run workflow** -> enter `v1.0.0` in the version field.

This will checkout `v1.0.0`, build the 4 binaries, create the GitHub Release with binaries + checksums, and push the Docker multi-arch image.