### PR TITLE
fix: release workflow -- actions:write permission, v-prefix, re-run protection

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -22,7 +22,8 @@ env:
   # Resolved once here, used everywhere.
   # - tag push or dispatch --ref "vX.Y.Z" : github.ref_name = vX.Y.Z, inputs.version = ''
   # - manual dispatch from main with version input : github.ref_name = main, inputs.version = vX.Y.Z
-  RELEASE_TAG: ${{ inputs.version != '' && inputs.version || github.ref_name }}
+  # Always normalise to "vX.Y.Z" -- works whether user typed "1.0.0" or "v1.0.0"
+  RELEASE_TAG: ${{ inputs.version != '' && (startsWith(inputs.version, 'v') && inputs.version || format('v{0}', inputs.version)) || github.ref_name }}
 
 jobs:
   # ── Compile binaries ─────────────────────────────────────────────────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to release -- e.g. 1.0.0 (no v prefix)'
+        description: 'Version to release -- e.g. 1.0.1 (no v prefix)'
         required: true
         type: string
 
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write  # required for gh workflow run (dispatch build-release.yml)
 
     steps:
       - uses: actions/checkout@v4
@@ -30,7 +31,6 @@ jobs:
       - name: Bump version in Cargo.toml
         run: |
           sed -i -E 's/^version = "[0-9]+\.[0-9]+\.[0-9]+"$/version = "${{ inputs.version }}"/' Cargo.toml
-          # Verify the replacement landed
           grep -E '^version = "${{ inputs.version }}"' Cargo.toml || {
             echo "::error::Version replacement failed"
             exit 1
@@ -41,7 +41,8 @@ jobs:
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Cargo.toml
-          git commit -m "chore: release v${{ inputs.version }}"
+          # No-op if version was already bumped (re-run on same version)
+          git diff --cached --quiet || git commit -m "chore: release v${{ inputs.version }}"
           git push
 
       - name: Create and push tag


### PR DESCRIPTION
## Fixes two bugs found during v1.0.1 release attempt

### Bug 1 -- HTTP 403 on `gh workflow run`

`GITHUB_TOKEN` needs `actions: write` to dispatch other workflows. Added to `release.yml`:

```yaml
permissions:
  contents: write
  actions: write  # this was missing
```

### Bug 2 -- `nothing to commit` crash on re-run

If the release workflow is re-run with the same version after a partial failure, `git commit` exits 1 because the bump is already committed:

```bash
git diff --cached --quiet || git commit -m "chore: release v1.0.1"
```

### Bonus -- v-prefix normalization in build-release.yml

`RELEASE_TAG` now accepts both `1.0.0` and `v1.0.0` as input.

## After merging

To build v1.0.1 (tag already exists): **Actions -> Build Release -> Run workflow** -> version: `v1.0.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)