### PR TITLE
fix: lowercase repo name for GHCR image tags

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -134,7 +134,8 @@ jobs:
           tag="${{ env.RELEASE_TAG }}"
           ver="${tag#v}"                                  # strip leading v
           major_minor="$(echo "$ver" | cut -d. -f1-2)"  # e.g. 1.0
-          repo="ghcr.io/${{ github.repository }}"
+          # GHCR requires lowercase -- github.repository preserves original casing
+          repo="ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')"
           echo "value=${repo}:${ver},${repo}:${major_minor},${repo}:latest" >> $GITHUB_OUTPUT
 
       - uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
## Bug

GHCR rejects image names with uppercase letters:

```
ERROR: invalid tag "ghcr.io/Etoile-Bleu/ZamSync:1.0.1": repository name must be lowercase
```

`github.repository` retourne `Etoile-Bleu/ZamSync` avec la casse originale.

## Fix

```bash
repo="ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')"
# => ghcr.io/etoile-bleu/zamsync:1.0.1
```

## After merging

Relancer **Actions -> Build Release -> Run workflow** -> `v1.0.1`