### PR TITLE
test: Phase 10 Tier 2 and Tier 3 coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2163,6 +2163,7 @@ dependencies = [
  "rustls",
  "rustls-pemfile",
  "tempfile",
+ "time",
  "tracing",
  "zamsync-core",
  "zamsync-storage",

--- a/crates/zamsync-network/Cargo.toml
+++ b/crates/zamsync-network/Cargo.toml
@@ -24,3 +24,4 @@ rcgen.workspace = true
 [dev-dependencies]
 zamsync-storage = { version = "1.0.3", path = "../zamsync-storage" }
 tempfile.workspace = true
+time = "0.3"

--- a/crates/zamsync-network/src/tls.rs
+++ b/crates/zamsync-network/src/tls.rs
@@ -311,4 +311,55 @@ mod tests {
             .client_config()
             .expect("client config builds -- rejection happens at handshake");
     }
+
+    /// A node cert whose `not_after` is in the past must be rejected by the
+    /// WebPki verifier -- this mirrors what rustls does at the TLS handshake.
+    #[test]
+    fn test_expired_cert_rejected_at_handshake() {
+        install_crypto_provider();
+
+        let ca_key = rcgen::KeyPair::generate().expect("CA key");
+        let mut ca_params =
+            rcgen::CertificateParams::new(vec!["ZamSync CA".to_string()]).expect("CA params");
+        ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        let ca_cert = ca_params.self_signed(&ca_key).expect("CA self-sign");
+
+        // Build a node cert whose validity window is entirely in the past (1970-01-01..1970-01-02).
+        let node_key = rcgen::KeyPair::generate().expect("node key");
+        let mut node_params =
+            rcgen::CertificateParams::new(vec!["zamsync.local".to_string()]).expect("node params");
+        node_params.not_before =
+            time::OffsetDateTime::from_unix_timestamp(0).expect("epoch start");
+        node_params.not_after =
+            time::OffsetDateTime::from_unix_timestamp(86400).expect("epoch + 1 day");
+        let expired_cert = node_params
+            .signed_by(&node_key, &ca_cert, &ca_key)
+            .expect("sign expired cert");
+
+        let ca_pem = ca_cert.pem();
+        let expired_pem = expired_cert.pem();
+
+        let ca_der: Vec<_> = rustls_pemfile::certs(&mut ca_pem.as_bytes())
+            .collect::<Result<Vec<_>, _>>()
+            .expect("parse CA DER");
+        let expired_der: Vec<_> = rustls_pemfile::certs(&mut expired_pem.as_bytes())
+            .collect::<Result<Vec<_>, _>>()
+            .expect("parse expired cert DER");
+
+        let mut root_store = rustls::RootCertStore::empty();
+        root_store.add(ca_der[0].clone()).expect("add CA to root store");
+
+        let verifier =
+            rustls::server::WebPkiClientVerifier::builder(Arc::new(root_store))
+                .build()
+                .expect("build verifier");
+
+        // Verify against current wall-clock time: the cert expired in 1970 so it must fail.
+        let now = rustls::pki_types::UnixTime::now();
+        let result = verifier.verify_client_cert(&expired_der[0], &[], now);
+        assert!(
+            result.is_err(),
+            "expired certificate must be rejected; got Ok instead"
+        );
+    }
 }

--- a/crates/zamsync-storage/tests/concurrent_test.rs
+++ b/crates/zamsync-storage/tests/concurrent_test.rs
@@ -1,0 +1,157 @@
+use std::sync::{Arc, Mutex};
+use tempfile::tempdir;
+use zamsync_core::ports::StateStore;
+use zamsync_core::{Event, NodeId, SequenceNumber, ZamResult};
+use zamsync_storage::{FilePeerStore, WalEventStore, ZamEngine};
+use zamsync_testing::run_direct_sync;
+
+type Engine = ZamEngine<WalEventStore, FilePeerStore, Counter>;
+
+#[derive(Default)]
+struct Counter {
+    count: usize,
+}
+
+impl StateStore for Counter {
+    fn apply_event(&mut self, _seq: SequenceNumber, _event: &Event) -> ZamResult<()> {
+        self.count += 1;
+        Ok(())
+    }
+    fn last_applied_seq(&self) -> Option<SequenceNumber> {
+        None
+    }
+}
+
+fn open_engine(dir: &tempfile::TempDir, node: NodeId) -> ZamResult<Engine> {
+    ZamEngine::open_wal(dir.path(), node, Counter::default())
+}
+
+/// Multiple threads sharing an engine via Mutex submit concurrently.
+/// No events must be lost and all sequence numbers must be unique.
+#[test]
+fn test_concurrent_writes_no_lost_events() {
+    const THREADS: usize = 8;
+    const EVENTS_PER_THREAD: usize = 100;
+    const TOTAL: usize = THREADS * EVENTS_PER_THREAD;
+
+    let dir = tempdir().unwrap();
+    let node = NodeId(1);
+    let engine = Arc::new(Mutex::new(open_engine(&dir, node).unwrap()));
+
+    let handles: Vec<_> = (0..THREADS)
+        .map(|t| {
+            let engine = Arc::clone(&engine);
+            std::thread::spawn(move || {
+                for i in 0..EVENTS_PER_THREAD {
+                    let payload = format!("t{t}-e{i}").into_bytes();
+                    engine.lock().unwrap().submit(1, payload).unwrap();
+                }
+            })
+        })
+        .collect();
+
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    engine.lock().unwrap().sync().unwrap();
+
+    // Reopen: open_wal replays all WAL records into state
+    let final_engine = open_engine(&dir, node).unwrap();
+    assert_eq!(
+        final_engine.state().count,
+        TOTAL,
+        "all {TOTAL} events must survive: no losses under concurrent submit"
+    );
+
+    // All sequence numbers must be unique (no double-write)
+    let scan_engine = open_engine(&dir, node).unwrap();
+    let mut seqs: Vec<u64> = scan_engine
+        .scan_events()
+        .unwrap()
+        .filter_map(|r| r.ok())
+        .map(|e| e.seq.0)
+        .collect();
+    let original_len = seqs.len();
+    seqs.sort_unstable();
+    seqs.dedup();
+    assert_eq!(
+        seqs.len(),
+        original_len,
+        "duplicate sequence numbers found -- concurrent WAL writes corrupted"
+    );
+    assert_eq!(seqs.len(), TOTAL, "sequence count must equal submitted count");
+}
+
+/// A node compacts while a new peer connects immediately after.
+/// This simulates the race between compaction and an incoming sync.
+/// The new peer must receive at least the post-compaction events with no
+/// corruption on either side.
+#[test]
+fn test_compaction_during_active_sync() {
+    let dir_a = tempdir().unwrap();
+    let dir_b = tempdir().unwrap();
+    let dir_c = tempdir().unwrap();
+    let node_a = NodeId(20);
+    let node_b = NodeId(21);
+    let node_c = NodeId(22);
+
+    // A submits 10 events
+    {
+        let mut engine_a = open_engine(&dir_a, node_a).unwrap();
+        for i in 0..10u32 {
+            engine_a
+                .submit(1, format!("event-{i}").into_bytes())
+                .unwrap();
+        }
+        engine_a.sync().unwrap();
+    }
+
+    // B syncs with A -- this lets A know B confirmed all 10 events
+    {
+        let mut engine_a = open_engine(&dir_a, node_a).unwrap();
+        let mut engine_b = open_engine(&dir_b, node_b).unwrap();
+        run_direct_sync(&mut engine_a, &mut engine_b).unwrap();
+        engine_a.sync().unwrap();
+        engine_b.sync().unwrap();
+    }
+
+    // A compacts (B confirmed all events) and immediately submits a new event --
+    // this is the moment C would be connecting in the real race
+    let dropped = {
+        let mut engine_a = open_engine(&dir_a, node_a).unwrap();
+        let d = engine_a.compact().unwrap();
+        engine_a.submit(1, b"post-compact".to_vec()).unwrap();
+        engine_a.sync().unwrap();
+        d
+    };
+    assert_eq!(dropped, 10, "all 10 pre-compaction events must be dropped");
+
+    // C connects right after compaction completes -- the WAL must still be
+    // consistent and C must receive the post-compact event
+    {
+        let mut engine_a = open_engine(&dir_a, node_a).unwrap();
+        let mut engine_c = open_engine(&dir_c, node_c).unwrap();
+        run_direct_sync(&mut engine_a, &mut engine_c).unwrap();
+        engine_c.sync().unwrap();
+    }
+
+    let engine_c = open_engine(&dir_c, node_c).unwrap();
+    assert!(
+        engine_c.state().count >= 1,
+        "C must receive at least the post-compact event; got {}",
+        engine_c.state().count
+    );
+
+    // A's WAL must be intact -- scan must not error
+    let engine_a = open_engine(&dir_a, node_a).unwrap();
+    let seqs: Vec<u64> = engine_a
+        .scan_events()
+        .unwrap()
+        .map(|r| r.expect("WAL corruption on A after compaction").seq.0)
+        .collect();
+    assert!(
+        !seqs.is_empty(),
+        "A's WAL must not be empty or corrupt after compaction"
+    );
+}

--- a/crates/zamsync-storage/tests/enospc_test.rs
+++ b/crates/zamsync-storage/tests/enospc_test.rs
@@ -1,0 +1,118 @@
+use zamsync_core::ports::{EventStore, StateStore};
+use zamsync_core::{Event, NodeId, SequenceNumber, ZamError, ZamResult};
+use zamsync_storage::ZamEngine;
+use zamsync_testing::{InMemoryEventStore, InMemoryPeerStore};
+
+// Event store that succeeds for the first `max` appends, then returns ENOSPC.
+struct FailAfterN {
+    inner: InMemoryEventStore,
+    max: usize,
+}
+
+impl FailAfterN {
+    fn new(max: usize) -> Self {
+        Self {
+            inner: InMemoryEventStore::new(),
+            max,
+        }
+    }
+}
+
+impl EventStore for FailAfterN {
+    fn next_seq(&self) -> SequenceNumber {
+        self.inner.next_seq()
+    }
+
+    fn append(&mut self, event: &Event) -> ZamResult<SequenceNumber> {
+        if self.inner.events().len() >= self.max {
+            return Err(ZamError::Io(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "no space left on device",
+            )));
+        }
+        self.inner.append(event)
+    }
+
+    fn scan(&self) -> ZamResult<Box<dyn Iterator<Item = ZamResult<Event>>>> {
+        self.inner.scan()
+    }
+
+    fn sync(&mut self) -> ZamResult<()> {
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct Counter {
+    count: usize,
+}
+
+impl StateStore for Counter {
+    fn apply_event(&mut self, _seq: SequenceNumber, _event: &Event) -> ZamResult<()> {
+        self.count += 1;
+        Ok(())
+    }
+    fn last_applied_seq(&self) -> Option<SequenceNumber> {
+        None
+    }
+}
+
+/// When the underlying store returns an I/O error (ENOSPC), `submit()` must
+/// propagate the error and leave the engine state fully consistent:
+/// no phantom events in the state projection, no corrupted sequence counter.
+#[test]
+fn test_submit_enospc_does_not_corrupt_state() {
+    const BEFORE_FULL: usize = 5;
+    let node_id = NodeId(1);
+
+    let event_store = FailAfterN::new(BEFORE_FULL);
+    let peer_store = InMemoryPeerStore::new(node_id);
+    let mut engine =
+        ZamEngine::new(node_id, event_store, peer_store, Counter::default()).unwrap();
+
+    // Fill the store to capacity
+    for i in 0..BEFORE_FULL {
+        engine
+            .submit(1, format!("event-{i}").into_bytes())
+            .unwrap_or_else(|e| panic!("submit {i} failed: {e}"));
+    }
+    assert_eq!(engine.state().count, BEFORE_FULL);
+
+    // Next submit must fail with an I/O error
+    let err = engine
+        .submit(1, b"overflow".to_vec())
+        .expect_err("submit must fail when store is full");
+    assert!(
+        matches!(err, ZamError::Io(_)),
+        "expected Io error, got: {err:?}"
+    );
+
+    // State must not be corrupted: exactly BEFORE_FULL events, no phantom
+    assert_eq!(
+        engine.state().count,
+        BEFORE_FULL,
+        "state must reflect only committed events after ENOSPC"
+    );
+
+    // Scan must return exactly BEFORE_FULL events with unique seqs
+    let events: Vec<Event> = engine
+        .scan_events()
+        .unwrap()
+        .filter_map(|r: ZamResult<Event>| r.ok())
+        .collect();
+    assert_eq!(
+        events.len(),
+        BEFORE_FULL,
+        "store must contain exactly the committed events"
+    );
+    let mut seqs: Vec<u64> = events.iter().map(|e| e.seq.0).collect();
+    seqs.sort_unstable();
+    seqs.dedup();
+    assert_eq!(seqs.len(), BEFORE_FULL, "no duplicate sequences after ENOSPC");
+
+    // Submit after the failure must still fail (store is still full)
+    assert!(
+        engine.submit(1, b"still-full".to_vec()).is_err(),
+        "subsequent submit must also fail while store is full"
+    );
+}


### PR DESCRIPTION
## Summary

Adds the remaining Phase 10 test coverage gaps across Tier 2 (important) and Tier 3 (nice to have).

### Tier 2 -- Advanced Durability

**`crates/zamsync-storage/tests/concurrent_test.rs`**

- `test_concurrent_writes_no_lost_events` -- 8 threads each call `submit()` 100 times through a shared `Arc<Mutex<ZamEngine>>`. After all threads join, reopens the engine and verifies all 800 events are present with no duplicate sequence numbers.
- `test_compaction_during_active_sync` -- A compacts its WAL and submits a new event immediately before C connects for the first time. Verifies C receives at least the post-compact event and A's WAL has no corruption.

### Tier 3 -- Edge Cases

**`crates/zamsync-storage/tests/enospc_test.rs`**

- `test_submit_enospc_does_not_corrupt_state` -- introduces a `FailAfterN` event store that returns `ZamError::Io("no space left on device")` after N appends. Verifies `submit()` propagates the error, the state projection shows exactly N events (no phantom), and subsequent submits still fail while the store is full.

**`crates/zamsync-network/src/tls.rs`**

- `test_expired_cert_rejected_at_handshake` -- generates a node cert whose `not_after` is 1970-01-02 (Unix epoch + 1 day), then passes it to `WebPkiClientVerifier::verify_client_cert` against the current wall-clock time. Verifies rustls returns an error for the expired certificate, matching the real mTLS handshake behavior.

## Test plan

- [ ] `cargo test --workspace` -- all tests pass with 0 failures
- [ ] New tests are visible in `cargo test -p zamsync-storage` and `cargo test -p zamsync-network`