### PR TITLE
feat(cmd): add zamsync project -- SQLite projection service (Phase 11)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -609,6 +621,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -802,6 +823,17 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1172,6 +1204,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -1770,6 +1816,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2121,13 +2173,14 @@ dependencies = [
 
 [[package]]
 name = "zamsync"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "axum",
  "futures",
  "log",
  "metrics",
  "metrics-exporter-prometheus",
+ "rusqlite",
  "serde",
  "serde_json",
  "sha2",
@@ -2144,7 +2197,7 @@ dependencies = [
 
 [[package]]
 name = "zamsync-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytecheck",
  "rkyv",
@@ -2155,7 +2208,7 @@ dependencies = [
 
 [[package]]
 name = "zamsync-network"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "byteorder",
  "log",
@@ -2173,7 +2226,7 @@ dependencies = [
 
 [[package]]
 name = "zamsync-storage"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "byteorder",
  "chacha20poly1305",
@@ -2191,7 +2244,7 @@ dependencies = [
 
 [[package]]
 name = "zamsync-testing"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "zamsync-core",
  "zamsync-storage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ tokio-stream = "0.1"
 futures = "0.3"
 serde.workspace = true
 serde_json.workspace = true
+rusqlite = { version = "0.32", features = ["bundled"] }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -126,16 +126,15 @@
 
 ### Projection Service
 
-- [ ] `zamsync project <data-dir> --target postgres://...` -- official projection service; reads the ZamSync WAL and inserts events into a target database via parameterized queries (zero SQL injection)
-- [ ] Persistent checkpoint: resumes from the last projected `seq` after restart; no duplicates in target database
-- [ ] Configurable batch size: `--batch-size 100` to group inserts and reduce network round-trips
-- [ ] Database support:
-  - [ ] **PostgreSQL** -- `INSERT ... ON CONFLICT DO NOTHING` on `(origin_node, seq)`
-  - [ ] **MySQL / MariaDB** -- `INSERT IGNORE INTO ...`
-  - [ ] **SQLite** -- local projection for embedded devices without PG
-  - [ ] **MongoDB** -- upsert on `{origin: node_id, seq: seq}`
-  - [ ] **ClickHouse** -- append-only table for health/IoT event analytics
-- [ ] Dry-run mode: `--dry-run` prints events that would be projected without touching the database
+- [x] `zamsync project <data-dir> [--target sqlite://path] [--batch-size N] [--dry-run]` -- reads the ZamSync WAL and inserts events into SQLite via `INSERT OR IGNORE` on `(origin_node_id, seq)`; idempotent -- safe to re-run
+- [x] Persistent deduplication: `UNIQUE(origin_node_id, seq)` constraint acts as implicit checkpoint; re-runs skip already-present events with zero risk of duplicates
+- [x] Configurable batch size: `--batch-size N` (default 100) groups inserts in a single transaction per batch
+- [x] **SQLite** -- local projection for embedded devices; bundled SQLite (no system dependency); schema with HLC index for time-range queries
+- [x] Dry-run mode: `--dry-run` lists events that would be projected without touching the database
+- [ ] **PostgreSQL** -- `INSERT ... ON CONFLICT DO NOTHING` on `(origin_node, seq)`
+- [ ] **MySQL / MariaDB** -- `INSERT IGNORE INTO ...`
+- [ ] **MongoDB** -- upsert on `{origin: node_id, seq: seq}`
+- [ ] **ClickHouse** -- append-only table for health/IoT event analytics
 
 ### Event Stream
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -4,6 +4,7 @@ mod compact;
 mod daemon;
 mod info;
 mod keygen;
+mod project;
 mod rekey;
 mod serve;
 mod sign;
@@ -16,6 +17,7 @@ pub use compact::run as compact;
 pub use daemon::run as daemon;
 pub use info::run as info;
 pub use keygen::run as keygen;
+pub use project::run as project;
 pub use rekey::run as rekey;
 pub use serve::run as serve;
 pub use sign::run as sign;
@@ -36,6 +38,7 @@ pub fn usage() {
   zamsync rekey   <data-dir> --old-key <path> --new-key <path>
   zamsync bench   <data-dir> [--events N]
   zamsync audit   <data-dir> [--format json|text] [--since <unix-ms>] [--node <id>] [--key-file <path>]
+  zamsync project <data-dir> [--target sqlite://path | postgres://...] [--batch-size N] [--dry-run] [--key-file <path>]
 
 Flags (serve / sync / daemon):
   --tls              Use mTLS with credentials in <data-dir>/tls/

--- a/src/cmd/project.rs
+++ b/src/cmd/project.rs
@@ -1,0 +1,230 @@
+use crate::util::{data_dir, flag_value, load_encryption_key, node_id_from_dir, open_engine};
+use rusqlite::{params, Connection};
+use std::path::{Path, PathBuf};
+use zamsync_core::Event;
+use zamsync_storage::PayloadSchema;
+
+pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
+    let dir = data_dir(args, 2)?;
+    let enc_key = load_encryption_key(args)?;
+    let dry_run = args.contains(&"--dry-run".to_string());
+    let batch_size: usize = flag_value(args, "--batch-size")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(100);
+
+    let db_path = resolve_db_path(args, &dir)?;
+
+    if dry_run {
+        eprintln!("[dry-run] would project to {}", db_path.display());
+    } else {
+        println!("projecting to {}", db_path.display());
+    }
+
+    let node_id = node_id_from_dir(&dir);
+    let engine = open_engine(&dir, node_id, enc_key, PayloadSchema::None)?;
+
+    let mut conn = if !dry_run {
+        let c = Connection::open(&db_path)?;
+        init_schema(&c)?;
+        Some(c)
+    } else {
+        None
+    };
+
+    let mut projected = 0usize;
+    let mut skipped = 0usize;
+    let mut batch: Vec<Event> = Vec::with_capacity(batch_size);
+
+    for result in engine.sorted_scan()? {
+        let event = result?;
+
+        if dry_run {
+            println!(
+                "node={} seq={} type={} size={}B hlc={}",
+                event.origin_node.0,
+                event.seq.0,
+                event.event_type,
+                event.payload.len(),
+                event.hlc.physical,
+            );
+            projected += 1;
+            continue;
+        }
+
+        batch.push(event);
+        if batch.len() >= batch_size {
+            let (p, s) = flush_batch(conn.as_mut().unwrap(), &batch)?;
+            projected += p;
+            skipped += s;
+            batch.clear();
+        }
+    }
+
+    if !dry_run {
+        if !batch.is_empty() {
+            let (p, s) = flush_batch(conn.as_mut().unwrap(), &batch)?;
+            projected += p;
+            skipped += s;
+        }
+        println!("{projected} projected, {skipped} already present");
+    } else {
+        println!("{projected} events would be projected");
+    }
+
+    Ok(())
+}
+
+fn resolve_db_path(
+    args: &[String],
+    data_dir: &Path,
+) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    match flag_value(args, "--target") {
+        None => Ok(data_dir.join("projection.db")),
+        Some(url) if url.starts_with("sqlite://") => {
+            Ok(PathBuf::from(url.trim_start_matches("sqlite://")))
+        }
+        Some(url) if url.starts_with("postgres://") || url.starts_with("postgresql://") => {
+            Err("PostgreSQL target not yet supported; use --target sqlite://path or omit for default".into())
+        }
+        Some(path) => Ok(PathBuf::from(path)),
+    }
+}
+
+fn init_schema(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS zamsync_events (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            origin_node_id  INTEGER NOT NULL,
+            seq             INTEGER NOT NULL,
+            hlc_ms          INTEGER NOT NULL,
+            hlc_logical     INTEGER NOT NULL,
+            event_type      INTEGER NOT NULL,
+            payload         BLOB    NOT NULL,
+            projected_at    TEXT    NOT NULL
+                            DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+            UNIQUE(origin_node_id, seq)
+        );
+        CREATE INDEX IF NOT EXISTS idx_origin_seq ON zamsync_events(origin_node_id, seq);
+        CREATE INDEX IF NOT EXISTS idx_hlc ON zamsync_events(hlc_ms, hlc_logical);",
+    )
+}
+
+fn flush_batch(
+    conn: &mut Connection,
+    events: &[Event],
+) -> Result<(usize, usize), Box<dyn std::error::Error>> {
+    let tx = conn.transaction()?;
+    let mut projected = 0usize;
+    let mut skipped = 0usize;
+
+    for ev in events {
+        let affected = tx.execute(
+            "INSERT OR IGNORE INTO zamsync_events \
+             (origin_node_id, seq, hlc_ms, hlc_logical, event_type, payload) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                ev.origin_node.0 as i64,
+                ev.seq.0 as i64,
+                ev.hlc.physical as i64,
+                ev.hlc.logical as i64,
+                ev.event_type as i64,
+                &ev.payload,
+            ],
+        )?;
+        if affected > 0 {
+            projected += 1;
+        } else {
+            skipped += 1;
+        }
+    }
+
+    tx.commit()?;
+    Ok((projected, skipped))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_init_schema_creates_table() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        init_schema(&conn).unwrap();
+
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='zamsync_events'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn test_init_schema_idempotent() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        init_schema(&conn).unwrap();
+        init_schema(&conn).unwrap(); // must not error
+    }
+
+    #[test]
+    fn test_flush_batch_inserts_and_skips() {
+        use zamsync_core::{Event, Hlc, NodeId, SequenceNumber};
+
+        let mut conn = Connection::open_in_memory().unwrap();
+        init_schema(&conn).unwrap();
+
+        let events = vec![
+            Event {
+                origin_node: NodeId(1),
+                seq: SequenceNumber(0),
+                hlc: Hlc::new(1000, 0),
+                event_type: 1,
+                payload: b"hello".to_vec(),
+            },
+            Event {
+                origin_node: NodeId(1),
+                seq: SequenceNumber(1),
+                hlc: Hlc::new(1001, 0),
+                event_type: 1,
+                payload: b"world".to_vec(),
+            },
+        ];
+
+        let (p, s) = flush_batch(&mut conn, &events).unwrap();
+        assert_eq!(p, 2);
+        assert_eq!(s, 0);
+
+        // Second flush -- both should be skipped (UNIQUE conflict)
+        let (p2, s2) = flush_batch(&mut conn, &events).unwrap();
+        assert_eq!(p2, 0);
+        assert_eq!(s2, 2);
+    }
+
+    #[test]
+    fn test_resolve_db_path_default() {
+        let dir = tempdir().unwrap();
+        let path = resolve_db_path(&[], dir.path()).unwrap();
+        assert_eq!(path, dir.path().join("projection.db"));
+    }
+
+    #[test]
+    fn test_resolve_db_path_sqlite_url() {
+        let dir = tempdir().unwrap();
+        let args = vec!["--target".to_string(), "sqlite:///tmp/test.db".to_string()];
+        let path = resolve_db_path(&args, dir.path()).unwrap();
+        assert_eq!(path, PathBuf::from("/tmp/test.db"));
+    }
+
+    #[test]
+    fn test_resolve_db_path_postgres_errors() {
+        let dir = tempdir().unwrap();
+        let args = vec![
+            "--target".to_string(),
+            "postgres://localhost/db".to_string(),
+        ];
+        assert!(resolve_db_path(&args, dir.path()).is_err());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Some("bench") => cmd::bench(&args),
         Some("daemon") => cmd::daemon(&args),
         Some("audit") => cmd::audit(&args),
+        Some("project") => cmd::project(&args),
         _ => {
             cmd::usage();
             std::process::exit(1);

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -116,6 +116,94 @@ fn test_compact_after_submit() {
     );
 }
 
+// ---- project -----------------------------------------------------------------
+
+#[test]
+fn test_project_creates_db_and_is_idempotent() {
+    let dir = tempfile::tempdir().unwrap();
+    let bin = bin();
+    let dir_s = dir.path().to_str().unwrap();
+
+    // Submit 3 events
+    for i in 0..3u32 {
+        Command::new(&bin)
+            .args(["submit", dir_s, &format!("record-{i}")])
+            .output()
+            .unwrap();
+    }
+
+    // First project run: should insert all 3
+    let out = Command::new(&bin)
+        .args(["project", dir_s])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "project failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("3 projected"),
+        "expected '3 projected' in output: {stdout}"
+    );
+    assert!(
+        stdout.contains("0 already present"),
+        "expected '0 already present' in output: {stdout}"
+    );
+
+    // projection.db must exist
+    assert!(
+        dir.path().join("projection.db").exists(),
+        "projection.db not created"
+    );
+
+    // Second run: all 3 already present, 0 newly projected
+    let out2 = Command::new(&bin)
+        .args(["project", dir_s])
+        .output()
+        .unwrap();
+    assert!(out2.status.success());
+    let stdout2 = String::from_utf8_lossy(&out2.stdout);
+    assert!(
+        stdout2.contains("0 projected") && stdout2.contains("3 already present"),
+        "second run should skip all: {stdout2}"
+    );
+}
+
+#[test]
+fn test_project_dry_run_no_file_created() {
+    let dir = tempfile::tempdir().unwrap();
+    let bin = bin();
+    let dir_s = dir.path().to_str().unwrap();
+
+    Command::new(&bin)
+        .args(["submit", dir_s, "event-1"])
+        .output()
+        .unwrap();
+
+    let out = Command::new(&bin)
+        .args(["project", dir_s, "--dry-run"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "project --dry-run failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("would be projected"),
+        "dry-run should mention 'would be projected': {stdout}"
+    );
+
+    // Must NOT create the database file
+    assert!(
+        !dir.path().join("projection.db").exists(),
+        "dry-run must not create projection.db"
+    );
+}
+
 // ---- serve + sync ------------------------------------------------------------
 
 /// Start hub on port 0 (OS picks the port), parse the actual address from


### PR DESCRIPTION
## Summary

New `zamsync project` command that reads the WAL and projects events into a SQLite database -- enabling integration with any SQL tooling without a native Rust SDK.

- **Idempotent**: `INSERT OR IGNORE` on `UNIQUE(origin_node_id, seq)` -- safe to re-run at any time, zero duplicates
- **Batched**: `--batch-size N` (default 100) wraps each batch in one SQLite transaction
- **Dry-run**: `--dry-run` lists what would be projected without touching the database
- **Bundled SQLite**: `rusqlite` with the `bundled` feature -- no system `libsqlite3` needed on any target platform
- **Default target**: `<data-dir>/projection.db` -- or `--target sqlite://path` for a custom location
- **PostgreSQL/MySQL targets**: return a clear "not yet supported" error (future phase)

Schema created automatically:

```sql
CREATE TABLE zamsync_events (
    origin_node_id  INTEGER,
    seq             INTEGER,
    hlc_ms          INTEGER,   -- HLC physical timestamp (ms)
    hlc_logical     INTEGER,
    event_type      INTEGER,
    payload         BLOB,
    projected_at    TEXT,      -- ISO 8601, auto-filled
    UNIQUE(origin_node_id, seq)
);
```

## Usage

```bash
# Project to default path (<data-dir>/projection.db)
zamsync project ./hub

# Custom SQLite file
zamsync project ./hub --target sqlite:///var/lib/analytics/events.db

# Preview without writing
zamsync project ./hub --dry-run

# Encrypted WAL
zamsync project ./hub --key-file ./hub/data.key --batch-size 500
```

## Tests

- 6 unit tests: schema init, idempotence, `flush_batch` insert/skip counts, path resolution (default, sqlite://, postgres:// error)
- 2 CLI integration tests: full round-trip with idempotent re-run; dry-run creates no file

## Test plan

- [ ] `cargo test --workspace` -- all green
- [ ] `cargo test --features integration --test cli_integration project` -- 2 pass
- [ ] Manual: `zamsync submit ./node hello && zamsync project ./node` -- shows "1 projected, 0 already present"
- [ ] Manual re-run: shows "0 projected, 1 already present"
- [ ] Manual: `--dry-run` prints event, no .db file created
