### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,66 @@
+name: Bug Report
+description: Something is broken or behaves unexpectedly
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill in as much detail as you can.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+      placeholder: When I run `zamsync sync ...`, it crashes with ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Minimal commands to trigger the bug.
+      placeholder: |
+        1. zamsync submit ./node "hello"
+        2. zamsync sync ./node 127.0.0.1:7000 <id>
+        3. Error: ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: The sync should complete without error.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: ZamSync version
+      placeholder: "1.1.1  (zamsync --version or from release tag)"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - Linux x86_64
+        - Linux ARM64 (Raspberry Pi 4)
+        - Linux ARMv7 (Raspberry Pi 2/3)
+        - Windows x86_64
+        - Docker (specify image tag in description)
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or output
+      description: Run with `RUST_LOG=debug` for more detail.
+      render: text

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,50 @@
+name: Feature Request
+description: Propose a new feature or enhancement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping shape ZamSync. Describe what you need and why.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the use case or pain point.
+      placeholder: When deploying to 100 clinics, I need to ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How would you like this to work? Include CLI flags, output format, etc.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds you tried, or other approaches you considered.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - CLI command
+        - Sync protocol
+        - Storage / WAL
+        - Security / TLS / PKI
+        - Prometheus metrics
+        - REST API
+        - Docker / deployment
+        - Projection (zamsync project)
+        - Documentation
+        - Testing
+        - Other
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/good_first_issue.yml
+++ b/.github/ISSUE_TEMPLATE/good_first_issue.yml
@@ -1,0 +1,52 @@
+name: Good First Issue (internal)
+description: Tracked task suitable for a first contribution -- maintainer use only
+labels: ["good first issue"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This template is for maintainers to create well-scoped entry-point tasks.
+        **Contributors:** look for open issues labelled `good first issue` instead of filing one here.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One sentence describing the change.
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context and motivation
+    validations:
+      required: true
+
+  - type: textarea
+    id: task
+    attributes:
+      label: Exact task
+      description: File to edit, function to add, test to write, etc.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: How do we know this is done?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: difficulty
+    attributes:
+      label: Estimated effort
+      options:
+        - "< 30 min -- trivial (typo, one-liner, doc-only)"
+        - "~1 h -- small (one function, one test)"
+        - "~2-4 h -- medium (new flag or filter, integration test)"
+        - "> 4 h -- larger (new backend, new command)"
+    validations:
+      required: true


### PR DESCRIPTION
## Summary

- Add `bug_report.yml` -- structured fields for description, steps to reproduce, expected behavior, version, platform, logs
- Add `feature_request.yml` -- fields for problem statement, proposed solution, alternatives, and area dropdown
- Add `good_first_issue.yml` -- maintainer-facing template for scoped entry-point tasks with effort estimate

## Why

GitHub renders YAML templates as guided forms instead of blank text boxes, which reduces noise and makes triage faster. The `good_first_issue` template gives maintainers a consistent format for publishing well-scoped tasks that attract first contributors.