### PR TITLE
fix(ci): apply cargo fmt across workspace

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,7 @@ macOS is not a supported target. It may work but is not tested in CI.
 
 ## PR guidelines
 
+- **CI must pass.** Every PR runs `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test --workspace` on Linux. Run them locally before pushing to avoid round-trips.
 - **One concern per PR.** A bug fix and a refactor go in separate PRs.
 - **Include a test** for any new behavior. CLI tests live in `tests/cli_integration.rs` (run with `--features integration`).
 - **No new runtime dependencies** unless strictly necessary. ZamSync compiles to a single static binary with zero system dependencies -- keep it that way.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <h1 align="center">ZamSync</h1>
-  <p align="center"><strong>Offline-first synchronization engine for intermittent-connectivity deployments</strong></p>
+  <p align="center"><strong>Resilient data replication for systems that cannot assume connectivity.</strong></p>
   <p align="center">
-    Deterministic WAL replication &bull; mTLS PKI &bull; WAL encryption at rest &bull; ARM64 / ARMv7 native
+    Works over 2G, satellite, or no internet for hours &bull; No dropped events. Ever.
   </p>
 </p>
 
@@ -20,55 +20,51 @@
 <!-- Regenerate: docker run --rm -v "${PWD}:/vhs" ghcr.io/charmbracelet/vhs docs/demos/quickstart.tape -->
 ![ZamSync demo](docs/demos/quickstart.gif)
 
-## 30-second Quick Start
+---
 
-No Rust, no Cargo. One binary, zero dependencies.
-
-**Linux / Raspberry Pi:**
-```bash
-curl -fsSL -o zamsync https://github.com/Etoile-Bleu/ZamSync/releases/latest/download/zamsync-linux-x86_64
-chmod +x zamsync && sudo mv zamsync /usr/local/bin/
-```
-
-**Docker:**
-```bash
-docker pull ghcr.io/etoile-bleu/zamsync:latest
-```
-
-**First sync between two nodes:**
+## Two nodes. Three commands.
 
 ```bash
-# Node A -- start listening
-zamsync serve ./node-a 0.0.0.0:7000
+# Node A: start listening
+zamsync serve ./a 0.0.0.0:7000
 
-# Node B (another terminal) -- write an event and sync to A
-zamsync submit ./node-b '{"patient": "P-001", "type": "visit"}'
-zamsync sync   ./node-b 127.0.0.1:7000 $(cat ./node-a/.node_id)
+# Node B: write an event and sync
+zamsync submit ./b '{"patient": "P-001", "type": "visit"}'
+zamsync sync   ./b 127.0.0.1:7000 $(cat ./a/.node_id)
 ```
 
 ```
-[node-b] connecting to 127.0.0.1:7000...
 [node-b] handshake ok  peer=a3f2c1d8
 [node-b] sent 1 event
 [node-b] sync complete in 12ms
 ```
 
-Node A now has the event. If the connection drops mid-transfer, just run `sync` again -- only missing events are retransmitted.
+Connection dropped mid-transfer? Run `sync` again. Only missing events are retransmitted.
+
+No Rust, no Cargo. One binary, zero runtime dependencies.
+
+```bash
+curl -fsSL -o zamsync \
+  https://github.com/Etoile-Bleu/ZamSync/releases/latest/download/zamsync-linux-x86_64
+chmod +x zamsync && sudo mv zamsync /usr/local/bin/
+```
 
 ---
 
-## What is ZamSync?
+## Why ZamSync exists
 
-ZamSync is a systems-level synchronization engine for environments where network connectivity is unreliable, intermittent, or extremely low-bandwidth -- think 2G links, satellite connections, or Raspberry Pi nodes in remote clinics.
+Built for environments where connectivity is a privilege, not a guarantee.
 
-It provides **deterministic, bidirectional event replication** between nodes, designed to work correctly through:
+District clinics in rural Bhutan sync patient records to a central hospital hub over 2G cellular -- 600ms latency, 30 kbps bandwidth, and frequent power outages. ZamSync was designed to work correctly through:
 
-- hours or days of complete disconnection
-- mid-transfer connection cuts
-- duplicate deliveries and partial writes
-- power loss during a sync session
+- **hours or days** of complete disconnection
+- **mid-transfer connection cuts** -- resume exactly where it left off
+- **power loss** during a sync session -- the WAL survives crashes
+- **duplicate deliveries** and partial writes -- idempotent by design
 
-The reference deployment is the **Bhutan ePIS** (electronic patient information system), where district clinics sync patient records to a central hospital hub over 2G cellular with 600ms latency and frequent blackouts.
+Single static binary. Runs on a Raspberry Pi 2. 512 MB RAM minimum.
+
+**Long-term vision:** enable adoption in rural public health systems such as Bhutan's clinic network, where offline-first synchronization is not an optimization -- it is a requirement.
 
 ---
 
@@ -474,6 +470,8 @@ When `--max-peers` is reached the hub accepts the TCP connection but blocks
 the session start until a slot frees -- clients queue rather than being
 rejected.
 
+---
+
 ## Prometheus Metrics
 
 ```bash
@@ -488,6 +486,108 @@ curl http://localhost:9090/metrics
 | `zamsync_events_received_total` | Counter | Events received from a peer |
 | `zamsync_sync_duration_seconds` | Summary | Full sync session duration (quantiles: p50, p90, p99) |
 | `zamsync_vv_drift` | Gauge | Version Vector gap vs peer |
+
+---
+
+## Hospital Network Simulation
+
+Multi-clinic network simulation using **Docker + Toxiproxy** -- no VMs, no Ansible,
+runs on any machine that has Docker and works in CI.
+
+```bash
+# 4 clinics x 500 events, Bhutan 2G profile (600ms latency, 30 kbps)
+docker compose -f tests/docker-compose.network.yml \
+  up --build --abort-on-container-exit
+
+# Report is written to tests/results/report.html
+start tests\results\report.html   # Windows
+open  tests/results/report.html   # Linux
+```
+
+Override profile and scale:
+
+```bash
+PROFILE=satellite EVENTS=2000 CLINIC_COUNT=8 \
+  docker compose -f tests/docker-compose.network.yml \
+  up --build --abort-on-container-exit
+```
+
+Network profiles (applied via Toxiproxy):
+
+| Profile | Latency | Bandwidth | Scenario |
+|---------|---------|-----------|----------|
+| `bhutan_2g` (default) | 600ms ± 100ms | 30 kbps | Rural clinic, 2G/EDGE |
+| `satellite` | 1200ms ± 200ms | 100 kbps | Very remote, VSAT |
+| `urban_3g` | 80ms ± 20ms | 1 Mbps | Urban 3G baseline |
+
+The simulation runs **two back-to-back scenarios** and compares them:
+
+| Scenario | `--max-peers` | Description |
+|----------|--------------|-------------|
+| Sequential | 1 | Clinics queue -- baseline |
+| Concurrent | 16 | Clinics sync in parallel (Phase 14) |
+
+The generated report includes:
+- Hero speedup widget (e.g. **4.3x** faster on Rural 2G/EDGE)
+- Sync wall time: Sequential vs Concurrent (horizontal bar chart)
+- Per-clinic sync duration comparison
+- Prometheus quantile distribution (p50 / p90 / p99) scraped live from each hub
+- ZamSync bytes transferred vs IPFS estimated overhead
+- 9-row feature comparison table (mTLS, encryption at rest, access control, ARM support ...)
+
+---
+
+## Embedding in a Rust Application
+
+```toml
+[dependencies]
+zamsync-storage = { git = "https://github.com/Etoile-Bleu/ZamSync.git" }
+zamsync-core    = { git = "https://github.com/Etoile-Bleu/ZamSync.git" }
+```
+
+```rust
+use zamsync_core::{ports::StateStore, Event, SequenceNumber, ZamResult};
+use zamsync_storage::ZamEngine;
+
+struct PatientIndex {
+    records: std::collections::HashMap<String, serde_json::Value>,
+}
+
+impl StateStore for PatientIndex {
+    fn apply_event(&mut self, _seq: SequenceNumber, event: &Event) -> ZamResult<()> {
+        if let Ok(record) = serde_json::from_slice(&event.payload) {
+            let id: String = record["id"].as_str().unwrap_or("").to_string();
+            self.records.insert(id, record);
+        }
+        Ok(())
+    }
+    fn last_applied_seq(&self) -> Option<SequenceNumber> { None }
+}
+
+fn main() -> zamsync_core::ZamResult<()> {
+    let index = PatientIndex { records: Default::default() };
+    let mut engine = ZamEngine::open_wal("./data", zamsync_core::NodeId(1), index)?;
+    engine.submit(1, br#"{"id": "P-001", "name": "Dorji"}"#.to_vec())?;
+    Ok(())
+}
+```
+
+---
+
+## Building
+
+```bash
+cargo build --release
+
+# ARM cross-compilation
+cross build --release --target aarch64-unknown-linux-musl
+cross build --release --target armv7-unknown-linux-musleabihf
+
+# Tests
+cargo test --workspace
+cargo fmt --check
+cargo clippy --workspace --all-targets -- -D warnings
+```
 
 ---
 
@@ -540,124 +640,6 @@ services:
       --policy own
       --key-file /var/lib/zamsync/data.key
       --metrics 0.0.0.0:9090
-```
-
----
-
-## Embedding in a Rust Application
-
-```toml
-[dependencies]
-zamsync-storage = { git = "https://github.com/Etoile-Bleu/ZamSync.git" }
-zamsync-core    = { git = "https://github.com/Etoile-Bleu/ZamSync.git" }
-```
-
-```rust
-use zamsync_core::{ports::StateStore, Event, SequenceNumber, ZamResult};
-use zamsync_storage::ZamEngine;
-
-struct PatientIndex {
-    records: std::collections::HashMap<String, serde_json::Value>,
-}
-
-impl StateStore for PatientIndex {
-    fn apply_event(&mut self, _seq: SequenceNumber, event: &Event) -> ZamResult<()> {
-        if let Ok(record) = serde_json::from_slice(&event.payload) {
-            let id: String = record["id"].as_str().unwrap_or("").to_string();
-            self.records.insert(id, record);
-        }
-        Ok(())
-    }
-    fn last_applied_seq(&self) -> Option<SequenceNumber> { None }
-}
-
-fn main() -> zamsync_core::ZamResult<()> {
-    let index = PatientIndex { records: Default::default() };
-    let mut engine = ZamEngine::open_wal("./data", zamsync_core::NodeId(1), index)?;
-    engine.submit(1, br#"{"id": "P-001", "name": "Dorji"}"#.to_vec())?;
-    Ok(())
-}
-```
-
----
-
-## Network Resilience Test
-
-ZamSync ships with a Toxiproxy-based E2E test simulating real Bhutan 2G conditions:
-
-- 600ms latency + 100ms jitter + 30 KB/s bandwidth cap
-- Mid-sync connection cut after 2 seconds
-- 5,000 events verified with zero loss or duplication after reconnect
-
-```bash
-docker compose -f tests/docker-compose.test.yml up --build --abort-on-container-exit
-```
-
-See [tests/README.md](tests/README.md) for details.
-
----
-
-## Hospital Network Simulation
-
-Multi-clinic network simulation using **Docker + Toxiproxy** -- no VMs, no Ansible,
-runs on any machine that has Docker and works in CI.
-
-```bash
-# 4 clinics x 500 events, Bhutan 2G profile (600ms latency, 30 kbps)
-docker compose -f tests/docker-compose.network.yml \
-  up --build --abort-on-container-exit
-
-# Report is written to tests/results/report.html
-start tests\results\report.html   # Windows
-open  tests/results/report.html   # Linux
-```
-
-Override profile and scale:
-
-```bash
-PROFILE=satellite EVENTS=2000 CLINIC_COUNT=8 \
-  docker compose -f tests/docker-compose.network.yml \
-  up --build --abort-on-container-exit
-```
-
-Network profiles (applied via Toxiproxy):
-
-| Profile | Latency | Bandwidth | Scenario |
-|---------|---------|-----------|----------|
-| `bhutan_2g` (default) | 600ms ± 100ms | 30 kbps | Rural clinic, 2G/EDGE |
-| `satellite` | 1200ms ± 200ms | 100 kbps | Very remote, VSAT |
-| `urban_3g` | 80ms ± 20ms | 1 Mbps | Urban 3G baseline |
-
-The simulation runs **two back-to-back scenarios** and compares them:
-
-| Scenario | `--max-peers` | Description |
-|----------|--------------|-------------|
-| Sequential | 1 | Clinics queue -- baseline |
-| Concurrent | 16 | Clinics sync in parallel (Phase 14) |
-
-The generated report includes:
-- Hero speedup widget (e.g. **4.3x** faster on Rural 2G/EDGE)
-- Sync wall time: Sequential vs Concurrent (horizontal bar chart)
-- Per-clinic sync duration comparison
-- Prometheus quantile distribution (p50 / p90 / p99) scraped live from each hub
-- ZamSync bytes transferred vs IPFS estimated overhead
-- 9-row feature comparison table (mTLS, encryption at rest, access control, ARM support ...)
-
----
-
-## Building
-
-```bash
-cargo build --release
-
-# ARM cross-compilation
-cross build --release --target aarch64-unknown-linux-musl
-cross build --release --target armv7-unknown-linux-musleabihf
-
-# Tests
-cargo test --workspace
-cargo fmt --check
-cargo clippy --workspace --all-targets -- -D warnings
 ```
 
 ---

--- a/crates/zamsync-core/src/event.rs
+++ b/crates/zamsync-core/src/event.rs
@@ -152,7 +152,10 @@ mod tests {
         let mut h = Hlc::new(1000, 0);
         h.tick(50);
         assert_eq!(h.physical, 1000, "physical must not decrease");
-        assert_eq!(h.logical, 1, "logical increments when wall is behind physical");
+        assert_eq!(
+            h.logical, 1,
+            "logical increments when wall is behind physical"
+        );
     }
 
     #[test]
@@ -212,7 +215,10 @@ mod tests {
         let mut h = Hlc::default();
         let remote = Hlc::new(999, 42);
         h.sync(1, &remote);
-        assert!(h > remote, "local HLC must be strictly ahead of remote after sync");
+        assert!(
+            h > remote,
+            "local HLC must be strictly ahead of remote after sync"
+        );
     }
 
     #[test]

--- a/crates/zamsync-core/src/sync.rs
+++ b/crates/zamsync-core/src/sync.rs
@@ -78,7 +78,11 @@ mod tests {
         assert_eq!(vv.get(NodeId(1)), SequenceNumber(5));
         // Lower seq must not overwrite a higher one.
         vv.update(NodeId(1), SequenceNumber(3));
-        assert_eq!(vv.get(NodeId(1)), SequenceNumber(5), "VV must never decrease");
+        assert_eq!(
+            vv.get(NodeId(1)),
+            SequenceNumber(5),
+            "VV must never decrease"
+        );
         // Same seq is idempotent.
         vv.update(NodeId(1), SequenceNumber(5));
         assert_eq!(vv.get(NodeId(1)), SequenceNumber(5));
@@ -100,9 +104,16 @@ mod tests {
         remote.update(NodeId(1), SequenceNumber(10));
         remote.update(NodeId(2), SequenceNumber(5));
 
-        let gaps: HashMap<u32, SequenceNumber> =
-            local.find_gaps(&remote).into_iter().map(|(n, s)| (n.0, s)).collect();
-        assert_eq!(gaps[&1], SequenceNumber::ZERO, "unknown node: start from seq 0");
+        let gaps: HashMap<u32, SequenceNumber> = local
+            .find_gaps(&remote)
+            .into_iter()
+            .map(|(n, s)| (n.0, s))
+            .collect();
+        assert_eq!(
+            gaps[&1],
+            SequenceNumber::ZERO,
+            "unknown node: start from seq 0"
+        );
         assert_eq!(gaps[&2], SequenceNumber::ZERO);
     }
 
@@ -115,8 +126,11 @@ mod tests {
         remote.update(NodeId(1), SequenceNumber(10));
         remote.update(NodeId(2), SequenceNumber(3));
 
-        let gaps: HashMap<u32, SequenceNumber> =
-            local.find_gaps(&remote).into_iter().map(|(n, s)| (n.0, s)).collect();
+        let gaps: HashMap<u32, SequenceNumber> = local
+            .find_gaps(&remote)
+            .into_iter()
+            .map(|(n, s)| (n.0, s))
+            .collect();
         // local has node 1 up to seq 5, remote has 10 → need seq 6 (local.next())
         assert_eq!(gaps[&1], SequenceNumber(6));
         // node 2 is unknown to local → need from seq 0
@@ -187,10 +201,18 @@ mod tests {
         for i in 0..PEER_COUNT {
             if i < 100 {
                 // local has seq 5, remote has 10 → need seq 6
-                assert_eq!(gap_map[&i], SequenceNumber(6), "peer {i}: expected next seq 6");
+                assert_eq!(
+                    gap_map[&i],
+                    SequenceNumber(6),
+                    "peer {i}: expected next seq 6"
+                );
             } else {
                 // unknown to local → need from seq 0
-                assert_eq!(gap_map[&i], SequenceNumber::ZERO, "peer {i}: expected seq 0");
+                assert_eq!(
+                    gap_map[&i],
+                    SequenceNumber::ZERO,
+                    "peer {i}: expected seq 0"
+                );
             }
         }
     }

--- a/crates/zamsync-network/src/protocol/frame.rs
+++ b/crates/zamsync-network/src/protocol/frame.rs
@@ -139,7 +139,10 @@ mod tests {
         let huge = vec![0u8; MAX_FRAME_SIZE as usize];
         let mut buf = Vec::new();
         let result = write_frame(&mut buf, &huge);
-        assert!(result.is_err(), "payload at MAX_FRAME_SIZE must be rejected");
+        assert!(
+            result.is_err(),
+            "payload at MAX_FRAME_SIZE must be rejected"
+        );
         assert!(buf.is_empty(), "no bytes must be written on rejection");
     }
 
@@ -154,7 +157,7 @@ mod tests {
         let mut wire = Vec::new();
         wire.extend_from_slice(&oversized_len.to_be_bytes()); // length field
         wire.push(0x00); // flag byte (won't be reached)
-        // No actual payload bytes -- the error fires before the payload is read.
+                         // No actual payload bytes -- the error fires before the payload is read.
 
         let mut fb = FrameBuffer::new();
         let result = fb.try_read_frame(&mut Cursor::new(&wire));

--- a/crates/zamsync-network/src/protocol/frame_buf.rs
+++ b/crates/zamsync-network/src/protocol/frame_buf.rs
@@ -19,6 +19,12 @@ pub struct FrameBuffer {
     buf: Vec<u8>,
 }
 
+impl Default for FrameBuffer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl FrameBuffer {
     pub fn new() -> Self {
         Self { buf: Vec::new() }
@@ -32,9 +38,8 @@ impl FrameBuffer {
     ///
     /// Returns:
     /// * `Ok(Some(payload))` -- a complete, decompressed frame is ready.
-    /// * `Ok(None)`          -- not enough bytes yet; call again after the next
-    ///                          read opportunity.
-    /// * `Err(_)`            -- a real I/O or protocol error occurred.
+    /// * `Ok(None)` -- not enough bytes yet; call again after the next read opportunity.
+    /// * `Err(_)` -- a real I/O or protocol error occurred.
     pub fn try_read_frame(&mut self, stream: &mut impl Read) -> ZamResult<Option<Vec<u8>>> {
         // Fast path: if the buffer already holds a complete frame, return it
         // without touching the stream at all. This handles the case where a

--- a/crates/zamsync-network/src/protocol/frame_buf.rs
+++ b/crates/zamsync-network/src/protocol/frame_buf.rs
@@ -1,7 +1,7 @@
 use super::frame::MAX_FRAME_SIZE;
 use std::io::{ErrorKind, Read};
-use zstd;
 use zamsync_core::{ZamError, ZamResult};
+use zstd;
 
 /// Per-connection receive buffer.
 ///

--- a/crates/zamsync-network/src/tls.rs
+++ b/crates/zamsync-network/src/tls.rs
@@ -328,8 +328,7 @@ mod tests {
         let node_key = rcgen::KeyPair::generate().expect("node key");
         let mut node_params =
             rcgen::CertificateParams::new(vec!["zamsync.local".to_string()]).expect("node params");
-        node_params.not_before =
-            time::OffsetDateTime::from_unix_timestamp(0).expect("epoch start");
+        node_params.not_before = time::OffsetDateTime::from_unix_timestamp(0).expect("epoch start");
         node_params.not_after =
             time::OffsetDateTime::from_unix_timestamp(86400).expect("epoch + 1 day");
         let expired_cert = node_params
@@ -347,12 +346,13 @@ mod tests {
             .expect("parse expired cert DER");
 
         let mut root_store = rustls::RootCertStore::empty();
-        root_store.add(ca_der[0].clone()).expect("add CA to root store");
+        root_store
+            .add(ca_der[0].clone())
+            .expect("add CA to root store");
 
-        let verifier =
-            rustls::server::WebPkiClientVerifier::builder(Arc::new(root_store))
-                .build()
-                .expect("build verifier");
+        let verifier = rustls::server::WebPkiClientVerifier::builder(Arc::new(root_store))
+            .build()
+            .expect("build verifier");
 
         // Verify against current wall-clock time: the cert expired in 1970 so it must fail.
         let now = rustls::pki_types::UnixTime::now();

--- a/crates/zamsync-network/src/transport/tcp/peer.rs
+++ b/crates/zamsync-network/src/transport/tcp/peer.rs
@@ -56,8 +56,8 @@ impl Transport for TcpPeerTransport {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::transport::TcpTransport;
+    use super::*;
     use std::sync::{Arc, Barrier};
     use std::thread;
     use zamsync_core::ports::StateStore;
@@ -90,8 +90,7 @@ mod tests {
         let hub_id = NodeId(1000);
 
         {
-            let mut eng =
-                ZamEngine::open_wal(hub_dir.path(), hub_id, Counter::default()).unwrap();
+            let mut eng = ZamEngine::open_wal(hub_dir.path(), hub_id, Counter::default()).unwrap();
             eng.sync().unwrap();
         }
 
@@ -109,9 +108,10 @@ mod tests {
                 let peer_id = pt.peer_id();
                 let path = hub_path.clone();
                 let h = thread::spawn(move || {
-                    let mut eng =
-                        ZamEngine::open_wal(&path, hub_id, Counter::default()).unwrap();
-                    SyncSession::new(&mut eng, &mut pt).serve_one(peer_id).unwrap();
+                    let mut eng = ZamEngine::open_wal(&path, hub_id, Counter::default()).unwrap();
+                    SyncSession::new(&mut eng, &mut pt)
+                        .serve_one(peer_id)
+                        .unwrap();
                     eng.sync().unwrap();
                 });
                 handles.push(h);
@@ -133,7 +133,8 @@ mod tests {
                 let mut eng =
                     ZamEngine::open_wal(dir.path(), clinic_id, Counter::default()).unwrap();
                 for j in 0..EVENTS_PER_CLINIC {
-                    eng.submit(1, format!("clinic-{i}-evt-{j}").into_bytes()).unwrap();
+                    eng.submit(1, format!("clinic-{i}-evt-{j}").into_bytes())
+                        .unwrap();
                 }
                 eng.sync().unwrap();
 
@@ -141,7 +142,9 @@ mod tests {
 
                 let mut transport = TcpTransport::bind("127.0.0.1:0").unwrap();
                 transport.connect(NodeId(1000), &addr).unwrap();
-                SyncSession::new(&mut eng, &mut transport).sync(NodeId(1000)).unwrap();
+                SyncSession::new(&mut eng, &mut transport)
+                    .sync(NodeId(1000))
+                    .unwrap();
             });
             clinic_handles.push(h);
         }

--- a/crates/zamsync-network/src/transport/tcp/peer.rs
+++ b/crates/zamsync-network/src/transport/tcp/peer.rs
@@ -57,7 +57,6 @@ impl Transport for TcpPeerTransport {
 #[cfg(test)]
 mod tests {
     use super::super::transport::TcpTransport;
-    use super::*;
     use std::sync::{Arc, Barrier};
     use std::thread;
     use zamsync_core::ports::StateStore;

--- a/crates/zamsync-network/src/transport/tcp/transport.rs
+++ b/crates/zamsync-network/src/transport/tcp/transport.rs
@@ -77,7 +77,10 @@ impl TcpTransport {
         let node_id = match &msg {
             SyncMessage::Handshake { node_id, .. } => *node_id,
             other => {
-                warn!(?other, "expected Handshake as first message, closing connection");
+                warn!(
+                    ?other,
+                    "expected Handshake as first message, closing connection"
+                );
                 return Err(ZamError::Protocol(
                     "first message from peer must be a Handshake".into(),
                 ));
@@ -85,7 +88,8 @@ impl TcpTransport {
         };
 
         stream.set_read_timeout(Some(Duration::from_millis(50)))?;
-        self.peers.insert(node_id.0, PeerConn::new(stream, Some(msg)));
+        self.peers
+            .insert(node_id.0, PeerConn::new(stream, Some(msg)));
         info!(peer = node_id.0, %addr, "accepted peer via Handshake");
         Ok(node_id)
     }
@@ -234,7 +238,11 @@ mod tests {
 
         let b_count = b_thread.join().unwrap();
 
-        assert_eq!(eng_a.state().count, 5, "A should have all 5 events after sync");
+        assert_eq!(
+            eng_a.state().count,
+            5,
+            "A should have all 5 events after sync"
+        );
         assert_eq!(b_count, 5, "B should have all 5 events after sync");
         assert_eq!(stats.events_sent, 3, "A sent its 3 events to B");
         assert_eq!(stats.events_received, 2, "A received B's 2 events");

--- a/crates/zamsync-network/src/transport/tls_tcp/transport.rs
+++ b/crates/zamsync-network/src/transport/tls_tcp/transport.rs
@@ -144,7 +144,8 @@ impl TlsTcpTransport {
         };
 
         tls.set_read_timeout(Some(Duration::from_millis(50)))?;
-        self.peers.insert(node_id.0, TlsPeerConn::new(tls, Some(msg)));
+        self.peers
+            .insert(node_id.0, TlsPeerConn::new(tls, Some(msg)));
         info!(peer = node_id.0, %addr, "TLS peer accepted");
         Ok(node_id)
     }

--- a/crates/zamsync-storage/tests/concurrent_test.rs
+++ b/crates/zamsync-storage/tests/concurrent_test.rs
@@ -80,7 +80,11 @@ fn test_concurrent_writes_no_lost_events() {
         original_len,
         "duplicate sequence numbers found -- concurrent WAL writes corrupted"
     );
-    assert_eq!(seqs.len(), TOTAL, "sequence count must equal submitted count");
+    assert_eq!(
+        seqs.len(),
+        TOTAL,
+        "sequence count must equal submitted count"
+    );
 }
 
 /// A node compacts while a new peer connects immediately after.

--- a/crates/zamsync-storage/tests/convergence_test.rs
+++ b/crates/zamsync-storage/tests/convergence_test.rs
@@ -114,12 +114,27 @@ fn test_three_node_split_brain_convergence() -> Result<(), Box<dyn std::error::E
     assert_eq!(count_c, 6, "C must have all 6 events after full mesh sync");
 
     // Determinism: sorted event streams must be identical on all three nodes.
-    let sorted_a: Vec<Vec<u8>> = engine_a.sorted_scan()?.map(|r| r.unwrap().payload).collect();
-    let sorted_b: Vec<Vec<u8>> = engine_b.sorted_scan()?.map(|r| r.unwrap().payload).collect();
-    let sorted_c: Vec<Vec<u8>> = engine_c.sorted_scan()?.map(|r| r.unwrap().payload).collect();
+    let sorted_a: Vec<Vec<u8>> = engine_a
+        .sorted_scan()?
+        .map(|r| r.unwrap().payload)
+        .collect();
+    let sorted_b: Vec<Vec<u8>> = engine_b
+        .sorted_scan()?
+        .map(|r| r.unwrap().payload)
+        .collect();
+    let sorted_c: Vec<Vec<u8>> = engine_c
+        .sorted_scan()?
+        .map(|r| r.unwrap().payload)
+        .collect();
 
-    assert_eq!(sorted_a, sorted_b, "A and B must converge to identical sorted streams");
-    assert_eq!(sorted_b, sorted_c, "B and C must converge to identical sorted streams");
+    assert_eq!(
+        sorted_a, sorted_b,
+        "A and B must converge to identical sorted streams"
+    );
+    assert_eq!(
+        sorted_b, sorted_c,
+        "B and C must converge to identical sorted streams"
+    );
 
     // VVs must agree on every node's highest seq.
     let vv_a = engine_a.replication_state().local_vv.clone();
@@ -129,8 +144,16 @@ fn test_three_node_split_brain_convergence() -> Result<(), Box<dyn std::error::E
         let seq_a = vv_a.get(node_id);
         let seq_b = vv_b.get(node_id);
         let seq_c = vv_c.get(node_id);
-        assert_eq!(seq_a, seq_b, "VV for node {} must agree: A={:?} B={:?}", node_id.0, seq_a, seq_b);
-        assert_eq!(seq_b, seq_c, "VV for node {} must agree: B={:?} C={:?}", node_id.0, seq_b, seq_c);
+        assert_eq!(
+            seq_a, seq_b,
+            "VV for node {} must agree: A={:?} B={:?}",
+            node_id.0, seq_a, seq_b
+        );
+        assert_eq!(
+            seq_b, seq_c,
+            "VV for node {} must agree: B={:?} C={:?}",
+            node_id.0, seq_b, seq_c
+        );
     }
 
     Ok(())

--- a/crates/zamsync-storage/tests/enospc_test.rs
+++ b/crates/zamsync-storage/tests/enospc_test.rs
@@ -67,8 +67,7 @@ fn test_submit_enospc_does_not_corrupt_state() {
 
     let event_store = FailAfterN::new(BEFORE_FULL);
     let peer_store = InMemoryPeerStore::new(node_id);
-    let mut engine =
-        ZamEngine::new(node_id, event_store, peer_store, Counter::default()).unwrap();
+    let mut engine = ZamEngine::new(node_id, event_store, peer_store, Counter::default()).unwrap();
 
     // Fill the store to capacity
     for i in 0..BEFORE_FULL {
@@ -108,7 +107,11 @@ fn test_submit_enospc_does_not_corrupt_state() {
     let mut seqs: Vec<u64> = events.iter().map(|e| e.seq.0).collect();
     seqs.sort_unstable();
     seqs.dedup();
-    assert_eq!(seqs.len(), BEFORE_FULL, "no duplicate sequences after ENOSPC");
+    assert_eq!(
+        seqs.len(),
+        BEFORE_FULL,
+        "no duplicate sequences after ENOSPC"
+    );
 
     // Submit after the failure must still fail (store is still full)
     assert!(

--- a/crates/zamsync-storage/tests/enospc_test.rs
+++ b/crates/zamsync-storage/tests/enospc_test.rs
@@ -25,8 +25,7 @@ impl EventStore for FailAfterN {
 
     fn append(&mut self, event: &Event) -> ZamResult<SequenceNumber> {
         if self.inner.events().len() >= self.max {
-            return Err(ZamError::Io(std::io::Error::new(
-                std::io::ErrorKind::Other,
+            return Err(ZamError::Io(std::io::Error::other(
                 "no space left on device",
             )));
         }

--- a/crates/zamsync-storage/tests/rekey_test.rs
+++ b/crates/zamsync-storage/tests/rekey_test.rs
@@ -38,8 +38,7 @@ fn test_wal_rekey_all_records_readable_with_new_key() -> ZamResult<()> {
         assert_eq!(records.len(), 5, "old key must read all records");
 
         let start_seq = records.first().map(|r| r.seq).unwrap_or_default();
-        let mut writer =
-            WalWriter::open_encrypted(&tmp_path, start_seq, Arc::clone(&new_key))?;
+        let mut writer = WalWriter::open_encrypted(&tmp_path, start_seq, Arc::clone(&new_key))?;
         for r in &records {
             writer.append_at_seq(r.seq, &r.payload)?;
         }
@@ -54,7 +53,10 @@ fn test_wal_rekey_all_records_readable_with_new_key() -> ZamResult<()> {
         let records: Vec<_> = scanner.scan().collect::<ZamResult<_>>()?;
         assert_eq!(records.len(), 5, "new key must read all re-keyed records");
         for (record, expected) in records.iter().zip(payloads.iter()) {
-            assert_eq!(&record.payload, expected, "payload must survive rekey intact");
+            assert_eq!(
+                &record.payload, expected,
+                "payload must survive rekey intact"
+            );
         }
         assert_eq!(records[0].seq, SequenceNumber(0));
         assert_eq!(records[4].seq, SequenceNumber(4));
@@ -112,8 +114,7 @@ fn test_wal_rekey_preserves_seq_numbers() -> ZamResult<()> {
 
     // Write records with non-contiguous seq numbers (e.g. after a compaction).
     {
-        let mut w =
-            WalWriter::open_encrypted(&wal_path, SequenceNumber(10), Arc::clone(&old_key))?;
+        let mut w = WalWriter::open_encrypted(&wal_path, SequenceNumber(10), Arc::clone(&old_key))?;
         w.append_at_seq(SequenceNumber(10), b"r10")?;
         w.append_at_seq(SequenceNumber(20), b"r20")?;
         w.append_at_seq(SequenceNumber(30), b"r30")?;

--- a/crates/zamsync-storage/tests/sync_test.rs
+++ b/crates/zamsync-storage/tests/sync_test.rs
@@ -174,7 +174,11 @@ fn test_apply_replicated_idempotent() -> Result<(), Box<dyn std::error::Error>> 
     }
 
     let b_events: Vec<Event> = engine_b.scan_events()?.collect::<ZamResult<_>>()?;
-    assert_eq!(b_events.len(), 2, "repeated apply_replicated must be idempotent");
+    assert_eq!(
+        b_events.len(),
+        2,
+        "repeated apply_replicated must be idempotent"
+    );
     assert_eq!(b_events[0].payload, b"patient-P001");
     assert_eq!(b_events[1].payload, b"patient-P002");
 
@@ -209,18 +213,27 @@ fn test_event_batch_before_handshake_does_not_panic() -> Result<(), Box<dyn std:
             events: vec![early_event],
         },
     )?;
-    assert!(responses.is_empty(), "EventBatch must return no response messages");
+    assert!(
+        responses.is_empty(),
+        "EventBatch must return no response messages"
+    );
 
     // The event is applied to the WAL -- state is consistent.
     let events: Vec<Event> = engine.scan_events()?.collect::<ZamResult<_>>()?;
-    assert_eq!(events.len(), 1, "event must be stored even without a prior Handshake");
+    assert_eq!(
+        events.len(),
+        1,
+        "event must be stored even without a prior Handshake"
+    );
     assert_eq!(events[0].payload, b"early-payload");
 
     // A subsequent Handshake still works correctly.
     let handshake = engine.prepare_handshake();
     let mut engine_b = make_engine(NodeId(3))?;
     let responses = engine_b.handle_sync_message(NodeId(1), handshake)?;
-    assert!(responses.iter().any(|m| matches!(m, SyncMessage::SyncComplete)));
+    assert!(responses
+        .iter()
+        .any(|m| matches!(m, SyncMessage::SyncComplete)));
 
     Ok(())
 }

--- a/src/cmd/project.rs
+++ b/src/cmd/project.rs
@@ -83,9 +83,10 @@ fn resolve_db_path(
         Some(url) if url.starts_with("sqlite://") => {
             Ok(PathBuf::from(url.trim_start_matches("sqlite://")))
         }
-        Some(url) if url.starts_with("postgres://") || url.starts_with("postgresql://") => {
-            Err("PostgreSQL target not yet supported; use --target sqlite://path or omit for default".into())
-        }
+        Some(url) if url.starts_with("postgres://") || url.starts_with("postgresql://") => Err(
+            "PostgreSQL target not yet supported; use --target sqlite://path or omit for default"
+                .into(),
+        ),
         Some(path) => Ok(PathBuf::from(path)),
     }
 }

--- a/src/cmd/project.rs
+++ b/src/cmd/project.rs
@@ -150,7 +150,7 @@ mod tests {
 
     #[test]
     fn test_init_schema_creates_table() {
-        let mut conn = Connection::open_in_memory().unwrap();
+        let conn = Connection::open_in_memory().unwrap();
         init_schema(&conn).unwrap();
 
         let count: i64 = conn
@@ -165,7 +165,7 @@ mod tests {
 
     #[test]
     fn test_init_schema_idempotent() {
-        let mut conn = Connection::open_in_memory().unwrap();
+        let conn = Connection::open_in_memory().unwrap();
         init_schema(&conn).unwrap();
         init_schema(&conn).unwrap(); // must not error
     }

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -95,7 +95,15 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
             policy,
             max_peers,
         );
-        tls_loop(node_id, &dir, enc_key, schema, policy, max_peers, &mut transport);
+        tls_loop(
+            node_id,
+            &dir,
+            enc_key,
+            schema,
+            policy,
+            max_peers,
+            &mut transport,
+        );
     } else {
         let mut transport = TcpTransport::bind(bind_addr)?;
         println!(
@@ -105,7 +113,15 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
             policy,
             max_peers,
         );
-        tcp_loop(node_id, &dir, enc_key, schema, policy, max_peers, &mut transport);
+        tcp_loop(
+            node_id,
+            &dir,
+            enc_key,
+            schema,
+            policy,
+            max_peers,
+            &mut transport,
+        );
     }
     Ok(())
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -152,8 +152,16 @@ fn base64_encode(data: &[u8]) -> String {
         let n = (b0 << 16) | (b1 << 8) | b2;
         out.push(CHARS[(n >> 18) & 63] as char);
         out.push(CHARS[(n >> 12) & 63] as char);
-        out.push(if chunk.len() > 1 { CHARS[(n >> 6) & 63] as char } else { '=' });
-        out.push(if chunk.len() > 2 { CHARS[n & 63] as char } else { '=' });
+        out.push(if chunk.len() > 1 {
+            CHARS[(n >> 6) & 63] as char
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            CHARS[n & 63] as char
+        } else {
+            '='
+        });
     }
     out
 }
@@ -193,8 +201,7 @@ async fn submit(
     State(s): State<Arc<HttpState>>,
     Json(body): Json<SubmitRequest>,
 ) -> Result<Json<SubmitResponse>, AppError> {
-    let payload_bytes = serde_json::to_vec(&body.payload)
-        .map_err(|e| AppError(e.to_string()))?;
+    let payload_bytes = serde_json::to_vec(&body.payload).map_err(|e| AppError(e.to_string()))?;
     let event_type = body.event_type;
     let node_id = s.node_id;
 
@@ -229,9 +236,8 @@ async fn events(
     let evts = tokio::task::spawn_blocking({
         let s = s.clone();
         move || -> Result<Vec<EventJson>, String> {
-            let engine =
-                open_engine(&s.data_dir, s.node_id, s.enc_key(), PayloadSchema::None)
-                    .map_err(|e| e.to_string())?;
+            let engine = open_engine(&s.data_dir, s.node_id, s.enc_key(), PayloadSchema::None)
+                .map_err(|e| e.to_string())?;
             let evts = engine
                 .scan_events()
                 .map_err(|e| e.to_string())?
@@ -265,8 +271,7 @@ async fn events_stream(
             let current = last_seq;
             let evts: Vec<EventJson> = tokio::task::spawn_blocking(move || {
                 let engine =
-                    open_engine(&s.data_dir, s.node_id, s.enc_key(), PayloadSchema::None)
-                        .ok()?;
+                    open_engine(&s.data_dir, s.node_id, s.enc_key(), PayloadSchema::None).ok()?;
                 let evts: Vec<EventJson> = engine
                     .scan_events()
                     .ok()?

--- a/src/http.rs
+++ b/src/http.rs
@@ -144,7 +144,7 @@ fn to_event_json(e: &zamsync_core::Event) -> EventJson {
 
 fn base64_encode(data: &[u8]) -> String {
     const CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    let mut out = String::with_capacity((data.len() + 2) / 3 * 4);
+    let mut out = String::with_capacity(data.len().div_ceil(3) * 4);
     for chunk in data.chunks(3) {
         let b0 = chunk[0] as usize;
         let b1 = chunk.get(1).copied().unwrap_or(0) as usize;

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -23,7 +23,11 @@ fn bin() -> std::path::PathBuf {
             }
             p
         });
-    assert!(path.exists(), "zamsync binary not found at {}", path.display());
+    assert!(
+        path.exists(),
+        "zamsync binary not found at {}",
+        path.display()
+    );
     path
 }
 
@@ -81,10 +85,7 @@ fn test_submit_increments_event_count() {
         );
     }
 
-    let out = Command::new(&bin)
-        .args(["info", dir_s])
-        .output()
-        .unwrap();
+    let out = Command::new(&bin).args(["info", dir_s]).output().unwrap();
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(
         stdout.contains("events   : 3"),


### PR DESCRIPTION
## Summary

- Run `cargo fmt --all` to fix all formatting diffs flagged by CI (`cargo fmt --check`)
- Add one line to `CONTRIBUTING.md`: CI must pass before merging, with a reminder to run fmt/clippy/test locally

No logic changes, pure formatting.