### PR TITLE
fix(release): regenerate Cargo.lock before tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
             exit 1
           fi
 
+      - uses: dtolnay/rust-toolchain@stable
+
       - name: Bump version in Cargo.toml
         run: |
           sed -i -E 's/^version = "[0-9]+\.[0-9]+\.[0-9]+"$/version = "${{ inputs.version }}"/' Cargo.toml
@@ -37,11 +39,18 @@ jobs:
             exit 1
           }
 
+      - name: Regenerate Cargo.lock
+        # cargo generate-lockfile rewrites Cargo.lock to match the bumped Cargo.toml.
+        # Without this step, Cargo.lock still contains the old version and
+        # `cargo publish` fails with "files in the working directory contain changes
+        # that were not yet committed" -- even though the tag commit looks clean.
+        run: cargo generate-lockfile
+
       - name: Commit and push version bump PR branch
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Cargo.toml
+          git add Cargo.toml Cargo.lock
           # No-op if version was already bumped (re-run on same version)
           git diff --cached --quiet || git commit -m "chore: release v${{ inputs.version }}"
           # Push to a side branch -- branch protection blocks direct pushes to main


### PR DESCRIPTION
## Summary

- Installs Rust in the `prepare` job and runs `cargo generate-lockfile` after bumping `Cargo.toml`
- Commits both `Cargo.toml` and `Cargo.lock` together so the tag is always self-consistent
- Permanently fixes `cargo publish` failing with *"files in the working directory contain changes that were not yet committed into git: Cargo.lock"*

**Root cause:** `sed` bumped the version in `Cargo.toml` but no `cargo` command ever ran in the `prepare` job, so `Cargo.lock` kept the old version in its `[[package]]` entries. The tag pointed at this inconsistent commit; `cargo publish` detected the drift and refused to publish.