### PR TITLE
docs(sponsor): add GitHub Sponsors button and Supporting ZamSync section

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,10 @@
+# Funding links -- GitHub displays a "Sponsor" button on the repo page.
+# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+
+# GitHub Sponsors (enable at https://github.com/sponsors)
+github: Etoile-Bleu
+
+# Uncomment and fill in your username if you use these platforms:
+# ko_fi: your-ko-fi-username
+# buy_me_a_coffee: your-username
+# open_collective: zamsync

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   <img src="https://img.shields.io/badge/rust-1.75%2B-orange?style=flat-square" alt="Rust 1.75+">
   <img src="https://img.shields.io/badge/platforms-linux%20%7C%20arm64%20%7C%20armv7%20%7C%20windows-lightgrey?style=flat-square" alt="Platforms">
   <img src="https://img.shields.io/badge/docker-ghcr.io-2496ED?style=flat-square&logo=docker" alt="Docker">
+  <a href="https://github.com/sponsors/Etoile-Bleu"><img src="https://img.shields.io/badge/sponsor-%E2%9D%A4-ea4aaa?style=flat-square&logo=github-sponsors" alt="Sponsor"></a>
 </p>
 
 ---
@@ -652,6 +653,20 @@ services:
 3. Click Run
 
 The pipeline bumps `Cargo.toml`, tags the commit, builds 4 platform binaries, publishes a GitHub Release with SHA-256 checksums, pushes a Docker multi-arch image to GHCR, and runs a smoke test to verify the binary and image actually work.
+
+---
+
+## Supporting ZamSync
+
+ZamSync is an independent open-source project. If it saves you time or helps
+you build something meaningful, consider sponsoring its development.
+
+<a href="https://github.com/sponsors/Etoile-Bleu">
+  <img src="https://img.shields.io/badge/Sponsor%20on%20GitHub-%E2%9D%A4-ea4aaa?style=for-the-badge&logo=github-sponsors" alt="Sponsor on GitHub">
+</a>
+
+Sponsorships go directly toward infrastructure, hardware for ARM testing
+(Raspberry Pi nodes), and time spent on maintenance and new features.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `.github/FUNDING.yml` -- wires up the **Sponsor** button on the repo page (GitHub Sponsors via `Etoile-Bleu`)
- Adds sponsor badge to the shields row in README
- Adds **Supporting ZamSync** section in README with a large sponsor CTA and a one-line explanation of where funds go (infrastructure, ARM test hardware, maintenance)

## To activate

Go to [github.com/sponsors](https://github.com/sponsors) and enroll `Etoile-Bleu` -- the FUNDING.yml is already in place, the button appears automatically once the account is enrolled.

## Test plan

- [ ] Merge and check that the Sponsor button appears on the repo page
- [ ] Verify sponsor badge renders in README
- [ ] Verify "Supporting ZamSync" section appears before License