### PR TITLE
chore(community): CODE_OF_CONDUCT, PR template, CODEOWNERS, Dependabot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Default owner for everything
+* @Etoile-Bleu
+
+# Security-sensitive paths
+SECURITY.md @Etoile-Bleu
+crates/zamsync-network/ @Etoile-Bleu
+crates/zamsync-storage/ @Etoile-Bleu

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## What does this PR do?
+
+<!-- One paragraph describing the change and why it is needed. -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / cleanup
+- [ ] Documentation
+- [ ] CI / tooling
+
+## Checklist
+
+- [ ] `cargo fmt --all` passes
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
+- [ ] `cargo test --workspace` passes
+- [ ] Relevant tests added or updated
+- [ ] CHANGELOG / ROADMAP updated if applicable

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+    groups:
+      patch-updates:
+        update-types:
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    labels:
+      - dependencies

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as contributors and maintainers pledge to make participation in ZamSync a
+harassment-free experience for everyone, regardless of age, body size,
+disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the maintainer at **matheo.delbarre@epitech.eu**.
+All complaints will be reviewed and investigated promptly and fairly.
+
+The maintainer is obligated to maintain confidentiality with regard to the
+reporter of an incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.1.


### PR DESCRIPTION
## Summary

Brings the GitHub community health score from **71% to 100%**.

- `CODE_OF_CONDUCT.md` -- Contributor Covenant 2.1, contact via `matheo.delbarre@epitech.eu`
- `.github/PULL_REQUEST_TEMPLATE.md` -- checklist (fmt / clippy / tests) shown on every new PR
- `.github/CODEOWNERS` -- `@Etoile-Bleu` owns everything; security-sensitive paths called out explicitly
- `.github/dependabot.yml` -- weekly Cargo + GitHub Actions version bumps, patch updates grouped into a single PR

## After merging

Three remaining items require a **manual click** in Settings > Security:
- Enable **Dependabot security updates**
- Enable **Secret scanning non-provider patterns**
- Enable **Secret scanning validity checks**