### PR TITLE
feat(metrics): Phase 19 retention observability metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,10 +494,15 @@ curl http://localhost:9090/metrics
 | Metric | Type | Description |
 |---|---|---|
 | `zamsync_events_submitted_total` | Counter | Events appended to local WAL |
-| `zamsync_events_sent_total` | Counter | Events sent to a peer |
-| `zamsync_events_received_total` | Counter | Events received from a peer |
-| `zamsync_sync_duration_seconds` | Summary | Full sync session duration (quantiles: p50, p90, p99) |
-| `zamsync_vv_drift` | Gauge | Version Vector gap vs peer |
+| `zamsync_sync_events_sent_total` | Counter | Events sent to a peer during sync |
+| `zamsync_sync_events_received_total` | Counter | Events received from a peer during sync |
+| `zamsync_bytes_sent_total` | Counter | Wire bytes sent per peer session |
+| `zamsync_sync_duration_seconds` | Histogram | Full sync session duration (quantiles: p50, p90, p99) |
+| `zamsync_vv_drift_events` | Gauge | Version Vector gap vs peer (events behind) |
+| `zamsync_wal_size_bytes` | Gauge | Current WAL file size in bytes |
+| `zamsync_events_expired_total` | Counter | Events removed by retention policy (`expire` / `--retain`) |
+| `zamsync_wal_oldest_event_timestamp_seconds` | Gauge | HLC wall-clock of the oldest surviving event (Unix seconds) |
+| `zamsync_budget_exhausted_total` | Counter | Sessions ended early due to `--max-bytes` cap |
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -262,7 +262,7 @@ the WAL on a schedule so storage does not grow unboundedly.
 - [x] **Tombstone preservation**: tombstone records (empty payload) are always preserved through the WAL rewrite so compaction markers survive retention runs
 - [x] **Snapshot export**: `zamsync snapshot <data-dir> --output snapshot.bin` exports the current WAL as a self-contained bootstrap file; a new node can initialize from the snapshot instead of syncing all history
 - [x] **Retention report**: `zamsync info` shows `wal size`, `oldest` event date, and `newest` event date (projected full-disk rate deferred to Phase 20)
-- [ ] **Retention observability metrics**: expose WAL state and expiry activity in Prometheus -- `zamsync_wal_size_bytes` (gauge, current WAL file size), `zamsync_events_expired_total` (counter, incremented on each `expire_before` call), `zamsync_wal_oldest_event_timestamp` (gauge, Unix ms of oldest event); allows Grafana dashboards to alert before a hub runs out of SD-card space
+- [x] **Retention observability metrics**: `zamsync_wal_size_bytes` (gauge, updated after each sync session and after each expire run), `zamsync_events_expired_total` (counter, incremented on each `expire_before` call), `zamsync_wal_oldest_event_timestamp_seconds` (gauge, Unix seconds of oldest surviving event); `EventStore::byte_size()` default trait method avoids coupling the sync session to WAL internals
 
 ## Phase 20: Embedded Status Dashboard
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -262,6 +262,7 @@ the WAL on a schedule so storage does not grow unboundedly.
 - [x] **Tombstone preservation**: tombstone records (empty payload) are always preserved through the WAL rewrite so compaction markers survive retention runs
 - [x] **Snapshot export**: `zamsync snapshot <data-dir> --output snapshot.bin` exports the current WAL as a self-contained bootstrap file; a new node can initialize from the snapshot instead of syncing all history
 - [x] **Retention report**: `zamsync info` shows `wal size`, `oldest` event date, and `newest` event date (projected full-disk rate deferred to Phase 20)
+- [ ] **Retention observability metrics**: expose WAL state and expiry activity in Prometheus -- `zamsync_wal_size_bytes` (gauge, current WAL file size), `zamsync_events_expired_total` (counter, incremented on each `expire_before` call), `zamsync_wal_oldest_event_timestamp` (gauge, Unix ms of oldest event); allows Grafana dashboards to alert before a hub runs out of SD-card space
 
 ## Phase 20: Embedded Status Dashboard
 

--- a/crates/zamsync-core/src/ports/event_store.rs
+++ b/crates/zamsync-core/src/ports/event_store.rs
@@ -5,4 +5,9 @@ pub trait EventStore {
     fn append(&mut self, event: &Event) -> ZamResult<SequenceNumber>;
     fn scan(&self) -> ZamResult<Box<dyn Iterator<Item = ZamResult<Event>>>>;
     fn sync(&mut self) -> ZamResult<()>;
+    /// Current on-disk byte size of the backing store. Used for Prometheus metrics.
+    /// Returns 0 for in-memory or non-file-backed implementations.
+    fn byte_size(&self) -> u64 {
+        0
+    }
 }

--- a/crates/zamsync-storage/src/adapters/wal_event_store.rs
+++ b/crates/zamsync-storage/src/adapters/wal_event_store.rs
@@ -1,5 +1,6 @@
 use crate::encryption::EncryptionKey;
 use crate::wal::{WalScanner, WalWriter};
+use metrics::{counter, gauge};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -191,12 +192,15 @@ impl WalEventStore {
         // Decide what to keep: newer-than-cutoff OR within the last min_keep per node.
         let mut kept: Vec<(SequenceNumber, Vec<u8>)> = Vec::new();
         let mut dropped = 0usize;
+        let mut oldest_phys_ms_kept: Option<u64> = None;
 
         for (_node, records) in by_node {
             let len = records.len();
             let min_keep_start = len.saturating_sub(min_keep);
             for (i, (seq, payload, phys_ms)) in records.into_iter().enumerate() {
                 if phys_ms >= cutoff_ms || i >= min_keep_start {
+                    oldest_phys_ms_kept =
+                        Some(oldest_phys_ms_kept.map_or(phys_ms, |o: u64| o.min(phys_ms)));
                     kept.push((seq, payload));
                 } else {
                     dropped += 1;
@@ -205,6 +209,10 @@ impl WalEventStore {
         }
 
         if dropped == 0 {
+            gauge!("zamsync_wal_size_bytes").set(size_before as f64);
+            if let Some(oldest_ms) = oldest_phys_ms_kept {
+                gauge!("zamsync_wal_oldest_event_timestamp_seconds").set(oldest_ms as f64 / 1000.0);
+            }
             return Ok((0, 0));
         }
 
@@ -253,6 +261,12 @@ impl WalEventStore {
             None => WalWriter::open(&self.path, next_seq)?,
         };
 
+        counter!("zamsync_events_expired_total").increment(dropped as u64);
+        gauge!("zamsync_wal_size_bytes").set(size_after as f64);
+        if let Some(oldest_ms) = oldest_phys_ms_kept {
+            gauge!("zamsync_wal_oldest_event_timestamp_seconds").set(oldest_ms as f64 / 1000.0);
+        }
+
         Ok((dropped, bytes_freed))
     }
 }
@@ -296,6 +310,10 @@ impl EventStore for WalEventStore {
 
     fn sync(&mut self) -> ZamResult<()> {
         self.writer.sync().map_err(Into::into)
+    }
+
+    fn byte_size(&self) -> u64 {
+        std::fs::metadata(&self.path).map(|m| m.len()).unwrap_or(0)
     }
 }
 

--- a/crates/zamsync-storage/src/engine.rs
+++ b/crates/zamsync-storage/src/engine.rs
@@ -182,6 +182,12 @@ impl<E: EventStore, P: PeerStore, S: StateStore> ZamEngine<E, P, S> {
         self.event_store.scan()
     }
 
+    /// Current on-disk size of the backing event store in bytes.
+    /// Returns 0 for in-memory implementations.
+    pub fn wal_byte_size(&self) -> u64 {
+        self.event_store.byte_size()
+    }
+
     /// Returns all events in deterministic global order (HLC, NodeId) via LogSorter.
     /// This is the correct order for state projection when events from multiple nodes
     /// are present in the WAL.

--- a/crates/zamsync-storage/src/sync_session.rs
+++ b/crates/zamsync-storage/src/sync_session.rs
@@ -174,6 +174,7 @@ where
             "sync complete"
         );
         self.engine.sync()?;
+        gauge!("zamsync_wal_size_bytes").set(self.engine.wal_byte_size() as f64);
         Ok(stats)
     }
 
@@ -257,6 +258,7 @@ where
             "serve_one complete"
         );
         self.engine.sync()?;
+        gauge!("zamsync_wal_size_bytes").set(self.engine.wal_byte_size() as f64);
         Ok(stats)
     }
 


### PR DESCRIPTION
## Summary

- `EventStore::byte_size() -> u64` default trait method (returns 0 for in-memory impls) -- keeps `sync_session.rs` decoupled from WAL internals
- `WalEventStore` overrides `byte_size()` via `fs::metadata`
- `ZamEngine::wal_byte_size()` delegates to the event store
- `expire_before` tracks `oldest_phys_ms_kept` during the keep/drop pass and emits all three metrics after WAL rewrite
- `zamsync_wal_size_bytes` also updated after every sync session (`serve_one` + `sync`) so the gauge stays current between expire runs

New Prometheus metrics:

| Metric | Type | Description |
|---|---|---|
| `zamsync_wal_size_bytes` | Gauge | Current WAL file size in bytes |
| `zamsync_events_expired_total` | Counter | Events removed by retention policy |
| `zamsync_wal_oldest_event_timestamp_seconds` | Gauge | HLC wall-clock of oldest surviving event (Unix seconds) |

Note: `--metrics` is optional and hub-side only. Clinics running `sync`/`submit` are not affected.

## Test plan

- [ ] `cargo test --workspace` -- all tests pass
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` -- clean
- [ ] `zamsync serve ./hub 0.0.0.0:7000 --metrics 0.0.0.0:9090` then `curl http://localhost:9090/metrics | grep zamsync_wal`
- [ ] After `zamsync sync`, `zamsync_wal_size_bytes` updates
- [ ] After `zamsync expire ./hub --before 2099-01-01`, all three retention metrics appear