### PR TITLE
feat(http): Phase 20 -- embedded status dashboard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ rusqlite = { version = "0.33", features = ["bundled"] }
 tempfile.workspace = true
 
 [dev-dependencies]
+tower = { version = "0.4", features = ["util"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.61", features = [

--- a/src/cmd/info.rs
+++ b/src/cmd/info.rs
@@ -1,4 +1,4 @@
-use crate::util::{data_dir, flag_value, load_encryption_key, node_id_from_dir};
+use crate::util::{data_dir, flag_value, format_date, load_encryption_key, node_id_from_dir};
 use zamsync_core::{ports::StateStore, Event, SequenceNumber, ZamResult};
 use zamsync_storage::ZamEngine;
 
@@ -67,20 +67,4 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
-}
-
-/// Convert Unix milliseconds to `YYYY-MM-DD` (UTC) via reverse Julian Day Number.
-fn format_date(ms: u64) -> String {
-    let days = (ms / 86_400_000) as i64;
-    let jdn = days + 2_440_588;
-    let a = jdn + 32044;
-    let b = (4 * a + 3) / 146097;
-    let c = a - (146097 * b) / 4;
-    let d = (4 * c + 3) / 1461;
-    let e = c - (1461 * d) / 4;
-    let m = (5 * e + 2) / 153;
-    let day = e - (153 * m + 2) / 5 + 1;
-    let month = m + 3 - 12 * (m / 10);
-    let year = 100 * b + d - 4800 + m / 10;
-    format!("{:04}-{:02}-{:02}", year, month, day)
 }

--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -1,0 +1,399 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>ZamSync</title>
+  <style>
+    :root {
+      --bg:      #0d1117;
+      --surface: #161b22;
+      --border:  #30363d;
+      --text:    #e6edf3;
+      --muted:   #8b949e;
+      --green:   #3fb950;
+      --yellow:  #d29922;
+      --red:     #f85149;
+      --blue:    #58a6ff;
+    }
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: ui-monospace, 'Cascadia Code', 'Fira Mono', monospace;
+      min-height: 100dvh;
+      padding: 2rem clamp(1rem, 5vw, 3rem);
+    }
+
+    /* ---- Header ---- */
+    header {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      padding-bottom: 1.25rem;
+      border-bottom: 1px solid var(--border);
+      margin-bottom: 2rem;
+    }
+    .logo { font-size: 1.1rem; font-weight: 700; color: var(--blue); letter-spacing: 0.04em; }
+    .dot {
+      width: 9px; height: 9px;
+      border-radius: 50%;
+      background: var(--muted);
+      transition: background 0.4s;
+      flex-shrink: 0;
+    }
+    .dot.ok {
+      background: var(--green);
+      animation: pulse 2.5s infinite;
+    }
+    .dot.err { background: var(--red); }
+    @keyframes pulse {
+      0%   { box-shadow: 0 0 0 0   rgba(63,185,80,.6); }
+      70%  { box-shadow: 0 0 0 6px rgba(63,185,80,0); }
+      100% { box-shadow: 0 0 0 0   rgba(63,185,80,0); }
+    }
+    .status      { font-size: 0.75rem; color: var(--muted); }
+    .status.ok   { color: var(--green); }
+    .status.err  { color: var(--red); }
+    .node-badge {
+      margin-left: auto;
+      font-size: 0.7rem;
+      color: var(--muted);
+      background: var(--surface);
+      border: 1px solid var(--border);
+      padding: 0.2rem 0.6rem;
+      border-radius: 4px;
+    }
+
+    /* ---- Stat cards ---- */
+    .cards {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+      gap: 1rem;
+      margin-bottom: 2rem;
+    }
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 1.25rem 1.25rem 1rem;
+    }
+    .card-label {
+      font-size: 0.65rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--muted);
+      margin-bottom: 0.5rem;
+    }
+    .card-value {
+      font-size: 1.9rem;
+      font-weight: 700;
+      line-height: 1;
+      color: var(--text);
+    }
+    .card-value.blue { color: var(--blue); }
+    .card-sub { font-size: 0.7rem; color: var(--muted); margin-top: 0.4rem; }
+
+    /* ---- Live events table ---- */
+    .section-title {
+      font-size: 0.7rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--muted);
+      margin-bottom: 0.75rem;
+    }
+    .events-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.78rem;
+    }
+    .events-table th {
+      text-align: left;
+      color: var(--muted);
+      font-size: 0.65rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.07em;
+      padding: 0.4rem 0.75rem;
+      border-bottom: 1px solid var(--border);
+    }
+    .events-table td {
+      padding: 0.45rem 0.75rem;
+      border-bottom: 1px solid rgba(48,54,61,.5);
+      vertical-align: middle;
+      max-width: 320px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .events-table tr:last-child td { border-bottom: none; }
+    .events-table tbody tr { animation: fadein 0.15s ease; }
+    @keyframes fadein { from { opacity: 0; transform: translateY(-2px); } to { opacity: 1; transform: none; } }
+    .seq-badge {
+      font-size: 0.65rem;
+      color: var(--muted);
+      background: rgba(88,166,255,.08);
+      padding: 0.1rem 0.4rem;
+      border-radius: 3px;
+    }
+    .empty-state {
+      text-align: center;
+      color: var(--muted);
+      font-size: 0.8rem;
+      padding: 2rem 0;
+    }
+
+    /* ---- Footer ---- */
+    footer {
+      margin-top: 3rem;
+      padding-top: 1rem;
+      border-top: 1px solid var(--border);
+      font-size: 0.65rem;
+      color: var(--muted);
+      display: flex;
+      justify-content: space-between;
+    }
+  </style>
+</head>
+<body>
+
+<header>
+  <span class="dot" id="dot"></span>
+  <span class="logo">ZamSync</span>
+  <span class="status" id="status">connecting...</span>
+  <span class="node-badge" id="node-id">--</span>
+</header>
+
+<div class="cards">
+  <article class="card">
+    <div class="card-label">Events</div>
+    <div class="card-value blue" id="events">--</div>
+    <div class="card-sub" id="events-range">--</div>
+  </article>
+  <article class="card">
+    <div class="card-label">WAL Size</div>
+    <div class="card-value" id="wal-size">--</div>
+  </article>
+  <article class="card">
+    <div class="card-label">Uptime</div>
+    <div class="card-value" id="uptime">--</div>
+  </article>
+</div>
+
+<p class="section-title">Live stream</p>
+<table class="events-table">
+  <thead>
+    <tr>
+      <th>Seq</th>
+      <th>Node</th>
+      <th>Type</th>
+      <th>Payload</th>
+    </tr>
+  </thead>
+  <tbody id="events-body">
+    <tr><td colspan="4" class="empty-state">waiting for events...</td></tr>
+  </tbody>
+</table>
+
+<footer>
+  <span>ZamSync -- offline-first WAL sync</span>
+  <span id="last-updated"></span>
+</footer>
+
+<script>
+(function () {
+  'use strict';
+
+  const $ = id => document.getElementById(id);
+  const MAX_ROWS = 30;
+  const liveEvents = [];
+
+  // ---- Formatters ----
+
+  function fmtBytes(b) {
+    if (b === 0) return '0 B';
+    if (b < 1024) return b + ' B';
+    if (b < 1048576) return (b / 1024).toFixed(1) + ' KB';
+    return (b / 1048576).toFixed(2) + ' MB';
+  }
+
+  function fmtUptime(s) {
+    s = Math.max(0, Math.floor(s));
+    if (s < 60)   return s + 's';
+    if (s < 3600) return Math.floor(s / 60) + 'm ' + (s % 60) + 's';
+    const h = Math.floor(s / 3600);
+    const m = Math.floor((s % 3600) / 60);
+    return h + 'h ' + m + 'm';
+  }
+
+  function fmtPayload(val) {
+    const s = (val === null || val === undefined)
+      ? ''
+      : (typeof val === 'string' ? val : JSON.stringify(val));
+    return s.length > 72 ? s.slice(0, 69) + '...' : s;
+  }
+
+  // ---- Client-side uptime ticker (no server call) ----
+
+  let uptimeBase = 0;
+  let uptimeAnchor = performance.now();
+
+  function tickUptime() {
+    const elapsed = (performance.now() - uptimeAnchor) / 1000;
+    $('uptime').textContent = fmtUptime(uptimeBase + elapsed);
+  }
+  setInterval(tickUptime, 1000);
+
+  // ---- Stats fetch -- triggered by SSE event or page load ----
+
+  async function fetchStats() {
+    try {
+      const r = await fetch('/ui/data');
+      if (!r.ok) throw new Error('HTTP ' + r.status);
+      const d = await r.json();
+
+      uptimeBase = d.uptime_seconds;
+      uptimeAnchor = performance.now();
+      tickUptime();
+
+      $('node-id').textContent = 'node ' + d.node_id;
+      $('events').textContent = Number(d.events).toLocaleString();
+      $('wal-size').textContent = fmtBytes(d.wal_size_bytes);
+
+      const range = (d.oldest_event && d.newest_event)
+        ? d.oldest_event + ' -- ' + d.newest_event
+        : 'no events yet';
+      $('events-range').textContent = range;
+
+      setOnline();
+      $('last-updated').textContent = 'updated ' + new Date().toLocaleTimeString();
+    } catch (e) {
+      setError('stats unavailable');
+    }
+  }
+
+  // ---- Status helpers ----
+
+  function setOnline() {
+    $('dot').className = 'dot ok';
+    const s = $('status');
+    s.textContent = 'online';
+    s.className = 'status ok';
+  }
+
+  function setConnecting() {
+    $('dot').className = 'dot';
+    const s = $('status');
+    s.textContent = 'connecting...';
+    s.className = 'status';
+  }
+
+  function setError(msg) {
+    $('dot').className = 'dot err';
+    const s = $('status');
+    s.textContent = msg;
+    s.className = 'status err';
+  }
+
+  // ---- Live event table ----
+
+  function pushEvent(e) {
+    liveEvents.unshift(e);
+    if (liveEvents.length > MAX_ROWS) liveEvents.pop();
+    renderTable();
+  }
+
+  function renderTable() {
+    const tbody = $('events-body');
+    if (liveEvents.length === 0) {
+      const tr = document.createElement('tr');
+      const td = document.createElement('td');
+      td.colSpan = 4;
+      td.className = 'empty-state';
+      td.textContent = 'waiting for events...';
+      tr.appendChild(td);
+      tbody.replaceChildren(tr);
+      return;
+    }
+    const rows = liveEvents.map(e => {
+      const tr = document.createElement('tr');
+
+      const seqTd = document.createElement('td');
+      const badge = document.createElement('span');
+      badge.className = 'seq-badge';
+      badge.textContent = '#' + e.seq;
+      seqTd.appendChild(badge);
+
+      const nodeTd = document.createElement('td');
+      nodeTd.textContent = String(e.node_id);
+
+      const typeTd = document.createElement('td');
+      typeTd.textContent = String(e.event_type);
+
+      const payloadTd = document.createElement('td');
+      const fullPayload = JSON.stringify(e.payload);
+      payloadTd.textContent = fmtPayload(e.payload);
+      payloadTd.title = fullPayload;
+
+      tr.append(seqTd, nodeTd, typeTd, payloadTd);
+      return tr;
+    });
+    tbody.replaceChildren(...rows);
+  }
+
+  // ---- SSE with exponential backoff + Visibility API ----
+
+  let sseBackoff = 1000;
+  let sseTimer = null;
+  let es = null;
+
+  function connectSSE() {
+    if (es) { es.close(); es = null; }
+    clearTimeout(sseTimer);
+    setConnecting();
+
+    es = new EventSource('/events/stream');
+
+    es.onopen = () => {
+      sseBackoff = 1000;
+      // Refresh stats once connection is established
+      fetchStats();
+    };
+
+    es.onmessage = evt => {
+      try {
+        const e = JSON.parse(evt.data);
+        pushEvent(e);
+      } catch { /* ignore malformed frame */ }
+      // New event -> refresh aggregate stats
+      fetchStats();
+    };
+
+    es.onerror = () => {
+      es.close();
+      es = null;
+      const retryIn = (sseBackoff / 1000).toFixed(0);
+      setError('stream lost -- retry in ' + retryIn + 's');
+      if (!document.hidden) {
+        sseTimer = setTimeout(connectSSE, sseBackoff);
+      }
+      sseBackoff = Math.min(sseBackoff * 2, 30_000);
+    };
+  }
+
+  // Resume when tab becomes visible again
+  document.addEventListener('visibilitychange', () => {
+    if (!document.hidden) {
+      connectSSE();
+    }
+  });
+
+  // ---- Boot ----
+  fetchStats();
+  connectSSE();
+})();
+</script>
+</body>
+</html>

--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -299,7 +299,15 @@
 
   // ---- Live event table ----
 
+  // Tracks the highest seq seen so reconnects resume from the right position.
+  let lastKnownSeq = 0;
+  // Secondary dedup guard for any edge case where the server sends a duplicate.
+  const seenSeqs = new Set();
+
   function pushEvent(e) {
+    if (seenSeqs.has(e.seq)) return;
+    seenSeqs.add(e.seq);
+    if (e.seq > lastKnownSeq) lastKnownSeq = e.seq;
     liveEvents.unshift(e);
     if (liveEvents.length > MAX_ROWS) liveEvents.pop();
     renderTable();
@@ -354,7 +362,8 @@
     clearTimeout(sseTimer);
     setConnecting();
 
-    es = new EventSource('/events/stream');
+    // Resume from the last seen seq so reconnects never replay already-shown events.
+    es = new EventSource('/events/stream?since=' + lastKnownSeq);
 
     es.onopen = () => {
       sseBackoff = 1000;

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,29 +1,27 @@
 use std::convert::Infallible;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use axum::{
     extract::{Query, State},
-    http::StatusCode,
+    http::{header, StatusCode},
     response::{
         sse::{Event as SseEvent, KeepAlive, Sse},
-        IntoResponse, Json,
+        IntoResponse, Json, Response,
     },
     routing::{get, post},
     Router,
 };
 use futures::{Stream, StreamExt as _};
 use serde::{Deserialize, Serialize};
-use zamsync_core::{NodeId, SequenceNumber};
-use zamsync_storage::{EncryptionKey, PayloadSchema};
+use zamsync_core::{ports::StateStore, Event, NodeId, SequenceNumber};
+use zamsync_storage::{EncryptionKey, PayloadSchema, ZamEngine};
 
-use crate::util::open_engine;
+use crate::util::{format_date, open_engine};
 
 // ---------------------------------------------------------------------------
-// Shared state -- all fields must be Send + Sync.
-// EncryptionKey wraps a ChaCha20 cipher that may not be Sync, so we store
-// the raw 32-byte key and reconstruct per request.
+// Shared state
 // ---------------------------------------------------------------------------
 
 #[derive(Clone)]
@@ -32,6 +30,7 @@ pub struct HttpState {
     raw_key: Option<[u8; 32]>,
     node_id: NodeId,
     schema: PayloadSchema,
+    started_at: Instant,
 }
 
 impl HttpState {
@@ -49,7 +48,7 @@ pub struct HttpConfig {
 }
 
 // ---------------------------------------------------------------------------
-// Entry point -- runs in a dedicated OS thread with its own tokio runtime.
+// Entry point
 // ---------------------------------------------------------------------------
 
 pub fn spawn(config: HttpConfig) -> std::thread::JoinHandle<()> {
@@ -67,14 +66,10 @@ pub fn spawn(config: HttpConfig) -> std::thread::JoinHandle<()> {
             raw_key,
             node_id: config.node_id,
             schema: config.schema,
+            started_at: Instant::now(),
         });
 
-        let app = Router::new()
-            .route("/health", get(health))
-            .route("/submit", post(submit))
-            .route("/events", get(events))
-            .route("/events/stream", get(events_stream))
-            .with_state(state);
+        let app = build_router(state);
 
         rt.block_on(async {
             let listener = tokio::net::TcpListener::bind(&bind_addr)
@@ -84,6 +79,17 @@ pub fn spawn(config: HttpConfig) -> std::thread::JoinHandle<()> {
             axum::serve(listener, app).await.expect("http serve");
         });
     })
+}
+
+fn build_router(state: Arc<HttpState>) -> Router {
+    Router::new()
+        .route("/health", get(health))
+        .route("/submit", post(submit))
+        .route("/events", get(events))
+        .route("/events/stream", get(events_stream))
+        .route("/ui", get(dashboard))
+        .route("/ui/data", get(ui_data))
+        .with_state(state)
 }
 
 // ---------------------------------------------------------------------------
@@ -125,6 +131,37 @@ struct EventJson {
     node_id: String,
     event_type: u32,
     payload: serde_json::Value,
+}
+
+#[derive(Serialize)]
+struct UiData {
+    node_id: String,
+    events: usize,
+    wal_size_bytes: u64,
+    uptime_seconds: u64,
+    oldest_event: Option<String>,
+    newest_event: Option<String>,
+}
+
+// WAL scan state for /ui/data: collects count + oldest/newest timestamps in one pass.
+#[derive(Default)]
+struct DashState {
+    count: usize,
+    oldest_ms: Option<u64>,
+    newest_ms: Option<u64>,
+}
+
+impl StateStore for DashState {
+    fn apply_event(&mut self, _seq: SequenceNumber, event: &Event) -> zamsync_core::ZamResult<()> {
+        self.count += 1;
+        let phys = event.hlc.physical;
+        self.oldest_ms = Some(self.oldest_ms.map_or(phys, |o| o.min(phys)));
+        self.newest_ms = Some(self.newest_ms.map_or(phys, |n| n.max(phys)));
+        Ok(())
+    }
+    fn last_applied_seq(&self) -> Option<SequenceNumber> {
+        None
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -256,7 +293,6 @@ async fn events(
 }
 
 // SSE endpoint: polls every 500ms and streams new events as they appear.
-// Uses `unfold` so `last_seq` is properly threaded through each poll iteration.
 async fn events_stream(
     State(s): State<Arc<HttpState>>,
     Query(q): Query<SinceQuery>,
@@ -302,4 +338,215 @@ async fn events_stream(
             .interval(Duration::from_secs(15))
             .text("ping"),
     )
+}
+
+// Serves the embedded status dashboard with security headers.
+async fn dashboard() -> Response {
+    let html = include_str!("dashboard.html");
+    (
+        StatusCode::OK,
+        [
+            (header::CONTENT_TYPE, "text/html; charset=utf-8"),
+            (
+                header::HeaderName::from_static("content-security-policy"),
+                // Inline styles + scripts are ours; no external origins allowed.
+                "default-src 'self'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; connect-src 'self'; img-src 'none'",
+            ),
+            (header::X_CONTENT_TYPE_OPTIONS, "nosniff"),
+            (header::X_FRAME_OPTIONS, "SAMEORIGIN"),
+            (
+                header::HeaderName::from_static("referrer-policy"),
+                "no-referrer",
+            ),
+        ],
+        html,
+    )
+        .into_response()
+}
+
+// Returns aggregate node stats consumed by the dashboard.
+async fn ui_data(State(s): State<Arc<HttpState>>) -> Result<Json<UiData>, AppError> {
+    let node_id = format!("{:08x}", s.node_id.0);
+    let uptime_seconds = s.started_at.elapsed().as_secs();
+
+    let (events, wal_size_bytes, oldest_ms, newest_ms) = tokio::task::spawn_blocking({
+        let s = s.clone();
+        move || -> Result<(usize, u64, Option<u64>, Option<u64>), String> {
+            let engine: zamsync_storage::ZamEngine<
+                zamsync_storage::WalEventStore,
+                zamsync_storage::FilePeerStore,
+                DashState,
+            > = match s.raw_key {
+                Some(key) => ZamEngine::open_wal_encrypted(
+                    &*s.data_dir,
+                    s.node_id,
+                    DashState::default(),
+                    EncryptionKey::from_bytes(key),
+                )
+                .map_err(|e| e.to_string())?,
+                None => ZamEngine::open_wal(&*s.data_dir, s.node_id, DashState::default())
+                    .map_err(|e| e.to_string())?,
+            };
+            let st = engine.state();
+            let wal_size = engine.wal_byte_size();
+            Ok((st.count, wal_size, st.oldest_ms, st.newest_ms))
+        }
+    })
+    .await
+    .map_err(|e| AppError(e.to_string()))?
+    .map_err(AppError)?;
+
+    Ok(Json(UiData {
+        node_id,
+        events,
+        wal_size_bytes,
+        uptime_seconds,
+        oldest_event: oldest_ms.map(format_date),
+        newest_event: newest_ms.map(format_date),
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::Request};
+    use tower::ServiceExt as _;
+
+    fn make_state() -> (Arc<HttpState>, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let state = Arc::new(HttpState {
+            data_dir: Arc::new(dir.path().to_path_buf()),
+            raw_key: None,
+            node_id: NodeId(1),
+            schema: PayloadSchema::None,
+            started_at: Instant::now(),
+        });
+        (state, dir) // return dir so it stays alive for the test
+    }
+
+    #[tokio::test]
+    async fn ui_returns_html_200() {
+        let (state, _dir) = make_state();
+        let app = build_router(state);
+        let resp = app
+            .oneshot(Request::builder().uri("/ui").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let ct = resp
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(
+            ct.contains("text/html"),
+            "content-type must be text/html, got {ct}"
+        );
+    }
+
+    #[tokio::test]
+    async fn ui_has_security_headers() {
+        let (state, _dir) = make_state();
+        let app = build_router(state);
+        let resp = app
+            .oneshot(Request::builder().uri("/ui").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let headers = resp.headers();
+        assert!(
+            headers.contains_key("content-security-policy"),
+            "missing Content-Security-Policy"
+        );
+        assert!(
+            headers.contains_key(header::X_CONTENT_TYPE_OPTIONS),
+            "missing X-Content-Type-Options"
+        );
+        assert!(
+            headers.contains_key(header::X_FRAME_OPTIONS),
+            "missing X-Frame-Options"
+        );
+    }
+
+    #[tokio::test]
+    async fn ui_data_returns_valid_json() {
+        let (state, _dir) = make_state();
+        let app = build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/ui/data")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let ct = resp
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(ct.contains("application/json"), "got: {ct}");
+        let body = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let data: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(data["node_id"].is_string(), "node_id must be a string");
+        assert!(data["events"].is_number(), "events must be a number");
+        assert!(
+            data["wal_size_bytes"].is_number(),
+            "wal_size_bytes must be a number"
+        );
+        assert!(
+            data["uptime_seconds"].is_number(),
+            "uptime_seconds must be a number"
+        );
+    }
+
+    #[tokio::test]
+    async fn ui_data_node_id_matches_state() {
+        let (state, _dir) = make_state();
+        let expected = format!("{:08x}", state.node_id.0);
+        let app = build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/ui/data")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let data: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(data["node_id"].as_str().unwrap(), expected);
+    }
+
+    #[tokio::test]
+    async fn health_returns_ok() {
+        let (state, _dir) = make_state();
+        let app = build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let data: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(data["status"].as_str().unwrap(), "ok");
+    }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -118,6 +118,22 @@ pub fn open_engine(
     Ok(engine.with_schema(schema))
 }
 
+/// Convert Unix milliseconds to `YYYY-MM-DD` (UTC) via reverse Julian Day Number.
+pub fn format_date(ms: u64) -> String {
+    let days = (ms / 86_400_000) as i64;
+    let jdn = days + 2_440_588;
+    let a = jdn + 32044;
+    let b = (4 * a + 3) / 146097;
+    let c = a - (146097 * b) / 4;
+    let d = (4 * c + 3) / 1461;
+    let e = c - (1461 * d) / 4;
+    let m = (5 * e + 2) / 153;
+    let day = e - (153 * m + 2) / 5 + 1;
+    let month = m + 3 - 12 * (m / 10);
+    let year = 100 * b + d - 4800 + m / 10;
+    format!("{:04}-{:02}-{:02}", year, month, day)
+}
+
 fn rand_u32() -> u32 {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};

--- a/tests/docker-compose.network.yml
+++ b/tests/docker-compose.network.yml
@@ -25,7 +25,7 @@ services:
       context: ..
       dockerfile: Dockerfile
     container_name: zamsync_net_hub_seq
-    command: ["serve", "/var/lib/zamsync", "0.0.0.0:9000", "--max-peers", "1", "--metrics", "0.0.0.0:9090"]
+    command: ["serve", "/var/lib/zamsync", "0.0.0.0:9000", "--max-peers", "1", "--metrics", "0.0.0.0:9090", "--http", "0.0.0.0:8080"]
     volumes:
       - hub-seq-data:/var/lib/zamsync
     networks: [net-test]
@@ -35,7 +35,7 @@ services:
       context: ..
       dockerfile: Dockerfile
     container_name: zamsync_net_hub_con
-    command: ["serve", "/var/lib/zamsync", "0.0.0.0:9000", "--max-peers", "16", "--metrics", "0.0.0.0:9090"]
+    command: ["serve", "/var/lib/zamsync", "0.0.0.0:9000", "--max-peers", "16", "--metrics", "0.0.0.0:9090", "--http", "0.0.0.0:8080"]
     volumes:
       - hub-con-data:/var/lib/zamsync
     networks: [net-test]
@@ -72,9 +72,11 @@ services:
       HUB_SEQ_ADDR: "hub-seq:9000"
       HUB_SEQ_DATA: "/var/lib/hub-seq"
       HUB_SEQ_METRICS: "hub-seq:9090"
+      HUB_SEQ_HTTP: "hub-seq:8080"
       HUB_CON_ADDR: "hub-con:9000"
       HUB_CON_DATA: "/var/lib/hub-con"
       HUB_CON_METRICS: "hub-con:9090"
+      HUB_CON_HTTP: "hub-con:8080"
       CLINIC_COUNT: "${CLINIC_COUNT:-4}"
       EVENTS: "${EVENTS:-500}"
       PROFILE: "${PROFILE:-bhutan_2g}"

--- a/tests/network_scenario.sh
+++ b/tests/network_scenario.sh
@@ -25,9 +25,11 @@ TOXIPROXY_HOST="${TOXIPROXY_HOST:-toxiproxy}"
 HUB_SEQ_ADDR="${HUB_SEQ_ADDR:-hub-seq:9000}"
 HUB_SEQ_DATA="${HUB_SEQ_DATA:-/var/lib/hub-seq}"
 HUB_SEQ_METRICS="${HUB_SEQ_METRICS:-hub-seq:9090}"
+HUB_SEQ_HTTP="${HUB_SEQ_HTTP:-hub-seq:8080}"
 HUB_CON_ADDR="${HUB_CON_ADDR:-hub-con:9000}"
 HUB_CON_DATA="${HUB_CON_DATA:-/var/lib/hub-con}"
 HUB_CON_METRICS="${HUB_CON_METRICS:-hub-con:9090}"
+HUB_CON_HTTP="${HUB_CON_HTTP:-hub-con:8080}"
 CLINIC_COUNT="${CLINIC_COUNT:-4}"
 EVENTS="${EVENTS:-500}"
 PROFILE="${PROFILE:-bhutan_2g}"
@@ -124,6 +126,7 @@ run_scenario() {
   local HUB_DATA="$4"    # "/var/lib/hub-seq"
   local HUB_METRICS="$5" # "hub-seq:9090"
   local PORT_BASE="$6"   # 9000 for seq proxies, 9010 for con proxies
+  local HUB_HTTP="${7:-}" # "hub-seq:8080"
 
   local MODE_RESULTS="$RESULTS/$MODE"
   local WORK="/tmp/clinics-$MODE"
@@ -253,15 +256,56 @@ run_scenario() {
     ok "[$MODE] Phase 19: WAL not present (clinic-1 failed sync earlier, skip)"
   fi
 
+  # Phase 20: HTTP dashboard smoke check
+  step "[$MODE] Phase 20: HTTP dashboard smoke check"
+  if [ -n "$HUB_HTTP" ]; then
+    local ui_html="/tmp/${MODE}_ui.html"
+    if curl -sf --max-time 10 "http://$HUB_HTTP/ui" -o "$ui_html"; then
+      if grep -q "ZamSync" "$ui_html"; then
+        ok "[$MODE] /ui returns HTML with ZamSync branding"
+      else
+        err "[$MODE] /ui HTML missing ZamSync content"
+        FAILED=1
+      fi
+    else
+      err "[$MODE] /ui endpoint unreachable at http://$HUB_HTTP/ui"
+      FAILED=1
+    fi
+
+    local ui_node_id
+    if ui_node_id=$(curl -sf --max-time 10 "http://$HUB_HTTP/ui/data" | jq -r '.node_id // empty' 2>/dev/null); then
+      if [ -n "$ui_node_id" ]; then
+        ok "[$MODE] /ui/data node_id: $ui_node_id"
+      else
+        err "[$MODE] /ui/data JSON missing node_id field"
+        FAILED=1
+      fi
+    else
+      err "[$MODE] /ui/data endpoint unreachable or returned invalid JSON"
+      FAILED=1
+    fi
+
+    local ui_events
+    ui_events=$(curl -sf --max-time 10 "http://$HUB_HTTP/ui/data" | jq -r '.events // empty' 2>/dev/null || echo "")
+    if [ -n "$ui_events" ]; then
+      ok "[$MODE] /ui/data events: $ui_events"
+    else
+      err "[$MODE] /ui/data missing events field"
+      FAILED=1
+    fi
+  else
+    ok "[$MODE] Phase 20: HUB_HTTP not set, skipping dashboard check"
+  fi
+
   return $FAILED
 }
 
 # ---- Run both scenarios ------------------------------------------------------
 # Sequential first (port base 9000: clinics on 9001-9004)
-run_scenario "seq" "$HUB_SEQ_ADDR" "$HUB_SEQ_ID" "$HUB_SEQ_DATA" "$HUB_SEQ_METRICS" 9000
+run_scenario "seq" "$HUB_SEQ_ADDR" "$HUB_SEQ_ID" "$HUB_SEQ_DATA" "$HUB_SEQ_METRICS" 9000 "$HUB_SEQ_HTTP"
 
 # Concurrent second (port base 9010: clinics on 9011-9014)
-run_scenario "con" "$HUB_CON_ADDR" "$HUB_CON_ID" "$HUB_CON_DATA" "$HUB_CON_METRICS" 9010
+run_scenario "con" "$HUB_CON_ADDR" "$HUB_CON_ID" "$HUB_CON_DATA" "$HUB_CON_METRICS" 9010 "$HUB_CON_HTTP"
 
 # ---- Generate comparison report ---------------------------------------------
 step "Generating comparison report"


### PR DESCRIPTION
## Summary

- `/ui` -- embedded HTML dashboard, dark theme, zero external deps, `include_str!` at compile time
- `/ui/data` -- JSON: node_id, events, wal_size_bytes, uptime_seconds, oldest_event, newest_event
- SSE-driven: stats refresh on each new event from `/events/stream`, exponential backoff (1s..30s) on reconnect, Visibility API pauses reconnect when tab is hidden -- zero blind polling
- Uptime ticks client-side (no server call per tick)
- Security headers on `/ui`: CSP (no external origins), X-Content-Type-Options: nosniff, X-Frame-Options: SAMEORIGIN, Referrer-Policy: no-referrer
- All dynamic DOM via `textContent` -- XSS safe by construction
- `format_date` moved from `cmd/info.rs` to `util.rs` and shared

## Tests

- 5 axum unit tests via `tower::ServiceExt::oneshot`: `/ui` 200 + text/html, security headers present, `/ui/data` JSON schema, node_id round-trip, `/health` smoke
- Phase 20 E2E checks in `network_scenario.sh`: `/ui` HTML content and `/ui/data` JSON verified on both hub-seq and hub-con after sync scenario completes
- Both hubs in `docker-compose.network.yml` now start with `--http 0.0.0.0:8080`

## Test plan

- [ ] `cargo test --workspace` -- 122 tests pass
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` -- clean
- [ ] Start hub with `--http 0.0.0.0:8080`, open `http://localhost:8080/ui` in browser
- [ ] Submit an event via `/submit`, verify live stream table updates without page reload
- [ ] Close tab and reopen -- verify SSE reconnects and stats refresh automatically