### PR TITLE
feat(http): Phase 21 -- typed error codes + mdBook docs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,46 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install mdBook
+        run: |
+          curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.40/mdbook-v0.4.40-x86_64-unknown-linux-musl.tar.gz \
+            | tar -xz --directory /usr/local/bin
+
+      - name: Build docs
+        run: mdbook build docs
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/book
+
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /target
 .claude/
 /bench_data/
+/docs/book
 /tests/*.log
 /tests/results/
 /report.html

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1222,6 +1222,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2005,6 +2025,21 @@ dependencies = [
 
 [[package]]
 name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
@@ -2549,6 +2584,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
+ "tower 0.4.13",
  "tracing",
  "tracing-subscriber",
  "windows-sys 0.61.2",

--- a/README.md
+++ b/README.md
@@ -459,6 +459,28 @@ curl -N http://localhost:8080/events/stream
 | `/submit` | `POST` | Append an event (JSON body: `event_type`, `payload`) |
 | `/events` | `GET` | Fetch events; `?since=<seq>` filters to newer events |
 | `/events/stream` | `GET` | SSE stream -- new events pushed as they arrive |
+| `/ui` | `GET` | Browser status dashboard |
+| `/ui/data` | `GET` | Dashboard stats as JSON |
+
+### Error responses
+
+All errors return JSON with a stable machine-readable code:
+
+```json
+{
+  "error": "SCHEMA_VIOLATION",
+  "message": "missing required field: patient_id"
+}
+```
+
+| Code | HTTP | When |
+|------|------|------|
+| `INVALID_JSON` | 400 | Request body is not valid JSON or `Content-Type` is missing |
+| `SCHEMA_VIOLATION` | 422 | Payload fails the `--schema` validation rule |
+| `WAL_UNAVAILABLE` | 503 | WAL file unavailable (disk full, corrupt, permissions) |
+| `INTERNAL_ERROR` | 500 | Unexpected internal error |
+
+Full reference: [etoile-bleu.github.io/ZamSync/error-codes.html](https://etoile-bleu.github.io/ZamSync/error-codes.html)
 
 The HTTP server runs in a dedicated OS thread and opens a fresh engine per request -- no shared mutable state, same pattern as the CLI.
 

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,12 @@
+[book]
+title = "ZamSync"
+description = "Offline-first WAL sync engine for low-bandwidth environments"
+language = "en"
+src = "src"
+authors = ["Etoile-Bleu"]
+
+[output.html]
+site-url = "/ZamSync/"
+default-theme = "ayu"
+preferred-dark-theme = "ayu"
+git-repository-url = "https://github.com/Etoile-Bleu/ZamSync"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,0 +1,10 @@
+# Summary
+
+[Introduction](introduction.md)
+
+---
+
+# Reference
+
+- [REST API](rest-api.md)
+- [Error Codes](error-codes.md)

--- a/docs/src/error-codes.md
+++ b/docs/src/error-codes.md
@@ -1,0 +1,151 @@
+# Error Codes
+
+All ZamSync HTTP errors return a JSON body with two fields:
+
+```json
+{
+  "error": "SCHEMA_VIOLATION",
+  "message": "missing required field: patient_id"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `error` | string | Stable machine-readable code -- safe to `switch` on |
+| `message` | string | Human-readable detail -- may change between versions |
+
+Error codes are **additive and stable**: existing codes are never renamed or removed. New codes may be added in future versions.
+
+---
+
+## Code reference
+
+| Code | HTTP | When |
+|------|------|------|
+| [`INVALID_JSON`](#invalid_json) | 400 | Request body is not valid JSON or `Content-Type` is missing |
+| [`SCHEMA_VIOLATION`](#schema_violation) | 422 | Payload fails the `--schema` validation rule |
+| [`WAL_UNAVAILABLE`](#wal_unavailable) | 503 | WAL file unavailable (disk full, corrupt, permission error) |
+| [`INTERNAL_ERROR`](#internal_error) | 500 | Unexpected internal error |
+
+---
+
+## INVALID_JSON
+
+**HTTP 400 Bad Request**
+
+The request body could not be parsed as JSON, or the `Content-Type` header is not `application/json`.
+
+```bash
+# Trigger: malformed body
+curl -X POST http://localhost:8080/submit \
+  -H 'Content-Type: application/json' \
+  -d 'not json'
+```
+
+```json
+{
+  "error": "INVALID_JSON",
+  "message": "Failed to parse the request body as JSON: ..."
+}
+```
+
+**How to handle**
+
+Fix the request body. Ensure:
+- `Content-Type: application/json` header is present
+- Body is valid JSON
+- Body matches the expected shape: `{"payload": <any JSON>}`
+
+---
+
+## SCHEMA_VIOLATION
+
+**HTTP 422 Unprocessable Entity**
+
+The payload is valid JSON but fails the validation rule configured with `--schema` on the server.
+
+This error only occurs when the hub is started with `--schema json-required:<field1>,<field2>,...`. If no schema is configured, all payloads are accepted.
+
+```bash
+# Hub started with: --schema json-required:patient_id,type
+curl -X POST http://localhost:8080/submit \
+  -H 'Content-Type: application/json' \
+  -d '{"payload": {"name": "John"}}'
+```
+
+```json
+{
+  "error": "SCHEMA_VIOLATION",
+  "message": "missing required field: patient_id"
+}
+```
+
+**How to handle**
+
+Ensure the payload includes all required fields. Check the hub configuration for the `--schema` flag to know which fields are mandatory.
+
+```bash
+# Correct: includes all required fields
+curl -X POST http://localhost:8080/submit \
+  -H 'Content-Type: application/json' \
+  -d '{"payload": {"patient_id": "P-001", "type": "admission"}}'
+```
+
+---
+
+## WAL_UNAVAILABLE
+
+**HTTP 503 Service Unavailable**
+
+The WAL file cannot be read or written. This is a server-side problem -- the client request was valid.
+
+Common causes:
+
+- Disk full
+- Data directory deleted or moved
+- Filesystem mounted read-only
+- WAL file corrupted (use `zamsync info` to inspect)
+- Permission denied on the data directory
+
+```json
+{
+  "error": "WAL_UNAVAILABLE",
+  "message": "IO error: No space left on device (os error 28)"
+}
+```
+
+**How to handle**
+
+Retry with exponential backoff. The server will recover automatically once the underlying problem is resolved (disk freed, filesystem remounted, etc.). Do not retry immediately in a tight loop.
+
+```js
+// Retry pattern
+async function submitWithRetry(payload, maxRetries = 5) {
+  let delay = 1000;
+  for (let i = 0; i < maxRetries; i++) {
+    const r = await fetch('/submit', { method: 'POST', body: JSON.stringify({payload}) });
+    if (r.status !== 503) return r;
+    await new Promise(ok => setTimeout(ok, delay));
+    delay = Math.min(delay * 2, 30_000);
+  }
+}
+```
+
+---
+
+## INTERNAL_ERROR
+
+**HTTP 500 Internal Server Error**
+
+An unexpected error occurred inside ZamSync. This indicates a bug.
+
+```json
+{
+  "error": "INTERNAL_ERROR",
+  "message": "..."
+}
+```
+
+**How to handle**
+
+Please open an issue at [github.com/Etoile-Bleu/ZamSync/issues](https://github.com/Etoile-Bleu/ZamSync/issues) with the full `message` value and the ZamSync version (`zamsync --version`).

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,0 +1,41 @@
+# ZamSync
+
+ZamSync is an **offline-first WAL sync engine** designed for low-bandwidth, intermittent-connectivity environments (2G/3G). It is purpose-built for healthcare networks where clinics record events while disconnected and reconcile them with a central hub when connectivity is available.
+
+## Core properties
+
+| Property | Implementation |
+|---|---|
+| Offline-first | Local WAL on every node; syncs when connected |
+| Causal ordering | Hybrid Logical Clocks (HLC) across nodes |
+| Conflict detection | Version Vectors (VV) track divergent histories |
+| Encryption | ChaCha20-Poly1305 at rest + optional mTLS in transit |
+| Low footprint | ~9 MB static binary, ~7 MB RSS; runs on Raspberry Pi |
+
+## Quick start
+
+```bash
+# Start a hub node with TCP sync + HTTP API
+zamsync serve ./hub 0.0.0.0:9000 --http 0.0.0.0:8080
+
+# Submit an event
+curl -X POST http://localhost:8080/submit \
+  -H 'Content-Type: application/json' \
+  -d '{"payload": {"patient_id": "P-001", "type": "admission"}}'
+# {"seq":1,"node_id":"a3f2c1d8"}
+
+# Watch live via SSE
+curl -N http://localhost:8080/events/stream
+
+# Browser dashboard
+open http://localhost:8080/ui
+```
+
+## Documentation
+
+- [REST API](rest-api.md) -- all endpoints with request/response examples
+- [Error Codes](error-codes.md) -- structured error reference for client developers
+
+## Source
+
+[github.com/Etoile-Bleu/ZamSync](https://github.com/Etoile-Bleu/ZamSync)

--- a/docs/src/rest-api.md
+++ b/docs/src/rest-api.md
@@ -1,0 +1,143 @@
+# REST API
+
+ZamSync embeds an HTTP server when `--http` is passed to `serve`. Any language can integrate without a native SDK.
+
+```bash
+zamsync serve ./hub 0.0.0.0:9000 --http 0.0.0.0:8080
+```
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/health` | Node status and event count |
+| `POST` | `/submit` | Append an event to the WAL |
+| `GET` | `/events` | Fetch events (batch) |
+| `GET` | `/events/stream` | Real-time SSE push stream |
+| `GET` | `/ui` | Browser status dashboard |
+| `GET` | `/ui/data` | Dashboard data as JSON |
+
+---
+
+## GET /health
+
+Returns node identity and total event count. Always returns `200 OK`.
+
+```bash
+curl http://localhost:8080/health
+```
+
+```json
+{
+  "status": "ok",
+  "node_id": "a3f2c1d8",
+  "events": 42
+}
+```
+
+---
+
+## POST /submit
+
+Appends an event to the local WAL. The payload is any JSON value.
+
+```bash
+curl -X POST http://localhost:8080/submit \
+  -H 'Content-Type: application/json' \
+  -d '{"event_type": 1, "payload": {"patient_id": "P-001", "type": "admission"}}'
+```
+
+**Request body**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `payload` | any JSON | required | Event payload |
+| `event_type` | integer | `1` | Application-defined event type tag |
+
+**Response `200 OK`**
+
+```json
+{
+  "seq": 43,
+  "node_id": "a3f2c1d8"
+}
+```
+
+**Error responses** -- see [Error Codes](error-codes.md).
+
+---
+
+## GET /events
+
+Returns a batch of events. Use `?since=<seq>` to fetch only events after a given sequence number.
+
+```bash
+# All events
+curl http://localhost:8080/events
+
+# Events after seq 40
+curl 'http://localhost:8080/events?since=40'
+```
+
+**Response `200 OK`**
+
+```json
+[
+  {"seq": 41, "node_id": "a3f2c1d8", "event_type": 1, "payload": {...}},
+  {"seq": 42, "node_id": "a3f2c1d8", "event_type": 1, "payload": {...}}
+]
+```
+
+---
+
+## GET /events/stream
+
+Server-Sent Events stream. The server pushes each new event as it is committed. The connection stays open; the server sends a `ping` keepalive every 15 seconds.
+
+Pass `?since=<seq>` on reconnect to resume without replaying already-seen events.
+
+```bash
+curl -N http://localhost:8080/events/stream
+```
+
+```
+data: {"seq":44,"node_id":"a3f2c1d8","event_type":1,"payload":{...}}
+data: {"seq":45,"node_id":"a3f2c1d8","event_type":1,"payload":{...}}
+: ping
+```
+
+**Reconnect pattern (JavaScript)**
+
+```js
+let lastSeq = 0;
+function connect() {
+  const es = new EventSource(`/events/stream?since=${lastSeq}`);
+  es.onmessage = e => {
+    const ev = JSON.parse(e.data);
+    lastSeq = Math.max(lastSeq, ev.seq);
+  };
+}
+```
+
+---
+
+## GET /ui
+
+Serves the built-in browser dashboard (HTML). Secured with `Content-Security-Policy`, `X-Frame-Options`, and `X-Content-Type-Options` headers.
+
+---
+
+## GET /ui/data
+
+Returns aggregate node stats consumed by the dashboard. Can also be polled directly.
+
+```json
+{
+  "node_id": "a3f2c1d8",
+  "events": 42,
+  "wal_size_bytes": 18432,
+  "uptime_seconds": 3601,
+  "oldest_event": "2025-03-01",
+  "newest_event": "2025-06-20"
+}
+```

--- a/src/http.rs
+++ b/src/http.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use axum::{
-    extract::{Query, State},
+    extract::{rejection::JsonRejection, Query, State},
     http::{header, StatusCode},
     response::{
         sse::{Event as SseEvent, KeepAlive, Sse},
@@ -15,7 +15,7 @@ use axum::{
 };
 use futures::{Stream, StreamExt as _};
 use serde::{Deserialize, Serialize};
-use zamsync_core::{ports::StateStore, Event, NodeId, SequenceNumber};
+use zamsync_core::{ports::StateStore, Event, NodeId, SequenceNumber, ZamError};
 use zamsync_storage::{EncryptionKey, PayloadSchema, ZamEngine};
 
 use crate::util::{format_date, open_engine};
@@ -165,6 +165,84 @@ impl StateStore for DashState {
 }
 
 // ---------------------------------------------------------------------------
+// Error types
+// ---------------------------------------------------------------------------
+
+/// Typed HTTP API errors with stable machine-readable codes.
+///
+/// Codes are additive -- new codes may be added; existing codes are never renamed.
+#[derive(Debug)]
+enum AppError {
+    /// 400 -- request body is not valid JSON or Content-Type is missing.
+    InvalidJson(String),
+    /// 422 -- body is valid JSON but fails the configured --schema validation.
+    SchemaViolation(String),
+    /// 503 -- WAL file unavailable (disk full, corrupt, permission error).
+    Unavailable(String),
+    /// 500 -- unexpected internal error.
+    Internal(String),
+}
+
+#[derive(Serialize)]
+struct ErrorBody {
+    error: &'static str,
+    message: String,
+}
+
+impl AppError {
+    fn status(&self) -> StatusCode {
+        match self {
+            Self::InvalidJson(_) => StatusCode::BAD_REQUEST,
+            Self::SchemaViolation(_) => StatusCode::UNPROCESSABLE_ENTITY,
+            Self::Unavailable(_) => StatusCode::SERVICE_UNAVAILABLE,
+            Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+
+    fn code(&self) -> &'static str {
+        match self {
+            Self::InvalidJson(_) => "INVALID_JSON",
+            Self::SchemaViolation(_) => "SCHEMA_VIOLATION",
+            Self::Unavailable(_) => "WAL_UNAVAILABLE",
+            Self::Internal(_) => "INTERNAL_ERROR",
+        }
+    }
+
+    fn message(&self) -> &str {
+        match self {
+            Self::InvalidJson(m)
+            | Self::SchemaViolation(m)
+            | Self::Unavailable(m)
+            | Self::Internal(m) => m,
+        }
+    }
+}
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        (
+            self.status(),
+            Json(ErrorBody {
+                error: self.code(),
+                message: self.message().to_owned(),
+            }),
+        )
+            .into_response()
+    }
+}
+
+fn zam_to_app(e: ZamError) -> AppError {
+    let msg = e.to_string();
+    match e {
+        ZamError::Validation(m) => AppError::SchemaViolation(m),
+        ZamError::Io(_) | ZamError::Corruption(_) | ZamError::Storage(_) => {
+            AppError::Unavailable(msg)
+        }
+        _ => AppError::Internal(msg),
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -203,14 +281,6 @@ fn base64_encode(data: &[u8]) -> String {
     out
 }
 
-struct AppError(String);
-
-impl IntoResponse for AppError {
-    fn into_response(self) -> axum::response::Response {
-        (StatusCode::INTERNAL_SERVER_ERROR, self.0).into_response()
-    }
-}
-
 // ---------------------------------------------------------------------------
 // Handlers
 // ---------------------------------------------------------------------------
@@ -236,27 +306,30 @@ async fn health(State(s): State<Arc<HttpState>>) -> Json<HealthResponse> {
 
 async fn submit(
     State(s): State<Arc<HttpState>>,
-    Json(body): Json<SubmitRequest>,
+    body: Result<Json<SubmitRequest>, JsonRejection>,
 ) -> Result<Json<SubmitResponse>, AppError> {
-    let payload_bytes = serde_json::to_vec(&body.payload).map_err(|e| AppError(e.to_string()))?;
+    let Json(body) = body.map_err(|e| AppError::InvalidJson(e.to_string()))?;
+    let payload_bytes =
+        serde_json::to_vec(&body.payload).map_err(|e| AppError::Internal(e.to_string()))?;
     let event_type = body.event_type;
     let node_id = s.node_id;
 
     let seq = tokio::task::spawn_blocking({
         let s = s.clone();
-        move || -> Result<SequenceNumber, String> {
+        move || -> Result<SequenceNumber, AppError> {
             let mut engine = open_engine(&s.data_dir, s.node_id, s.enc_key(), s.schema.clone())
-                .map_err(|e| e.to_string())?;
+                .map_err(|e| AppError::Unavailable(e.to_string()))?;
             let seq = engine
                 .submit(event_type, payload_bytes)
-                .map_err(|e| e.to_string())?;
-            engine.sync().map_err(|e| e.to_string())?;
+                .map_err(zam_to_app)?;
+            engine
+                .sync()
+                .map_err(|e| AppError::Unavailable(e.to_string()))?;
             Ok(seq)
         }
     })
     .await
-    .map_err(|e| AppError(e.to_string()))?
-    .map_err(AppError)?;
+    .map_err(|e| AppError::Internal(e.to_string()))??;
 
     Ok(Json(SubmitResponse {
         seq: seq.0,
@@ -272,12 +345,12 @@ async fn events(
 
     let evts = tokio::task::spawn_blocking({
         let s = s.clone();
-        move || -> Result<Vec<EventJson>, String> {
+        move || -> Result<Vec<EventJson>, AppError> {
             let engine = open_engine(&s.data_dir, s.node_id, s.enc_key(), PayloadSchema::None)
-                .map_err(|e| e.to_string())?;
+                .map_err(|e| AppError::Unavailable(e.to_string()))?;
             let evts = engine
                 .scan_events()
-                .map_err(|e| e.to_string())?
+                .map_err(|e| AppError::Unavailable(e.to_string()))?
                 .filter_map(|r| r.ok())
                 .filter(|e| e.seq.0 >= since)
                 .map(|e| to_event_json(&e))
@@ -286,8 +359,7 @@ async fn events(
         }
     })
     .await
-    .map_err(|e| AppError(e.to_string()))?
-    .map_err(AppError)?;
+    .map_err(|e| AppError::Internal(e.to_string()))??;
 
     Ok(Json(evts))
 }
@@ -371,7 +443,7 @@ async fn ui_data(State(s): State<Arc<HttpState>>) -> Result<Json<UiData>, AppErr
 
     let (events, wal_size_bytes, oldest_ms, newest_ms) = tokio::task::spawn_blocking({
         let s = s.clone();
-        move || -> Result<(usize, u64, Option<u64>, Option<u64>), String> {
+        move || -> Result<(usize, u64, Option<u64>, Option<u64>), AppError> {
             let engine: zamsync_storage::ZamEngine<
                 zamsync_storage::WalEventStore,
                 zamsync_storage::FilePeerStore,
@@ -383,9 +455,9 @@ async fn ui_data(State(s): State<Arc<HttpState>>) -> Result<Json<UiData>, AppErr
                     DashState::default(),
                     EncryptionKey::from_bytes(key),
                 )
-                .map_err(|e| e.to_string())?,
+                .map_err(|e| AppError::Unavailable(e.to_string()))?,
                 None => ZamEngine::open_wal(&*s.data_dir, s.node_id, DashState::default())
-                    .map_err(|e| e.to_string())?,
+                    .map_err(|e| AppError::Unavailable(e.to_string()))?,
             };
             let st = engine.state();
             let wal_size = engine.wal_byte_size();
@@ -393,8 +465,7 @@ async fn ui_data(State(s): State<Arc<HttpState>>) -> Result<Json<UiData>, AppErr
         }
     })
     .await
-    .map_err(|e| AppError(e.to_string()))?
-    .map_err(AppError)?;
+    .map_err(|e| AppError::Internal(e.to_string()))??;
 
     Ok(Json(UiData {
         node_id,
@@ -427,6 +498,8 @@ mod tests {
         });
         (state, dir) // return dir so it stays alive for the test
     }
+
+    // ---- Dashboard tests ----
 
     #[tokio::test]
     async fn ui_returns_html_200() {
@@ -548,5 +621,161 @@ mod tests {
             .unwrap();
         let data: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(data["status"].as_str().unwrap(), "ok");
+    }
+
+    // ---- Error code tests ----
+
+    #[tokio::test]
+    async fn submit_invalid_json_returns_400() {
+        let (state, _dir) = make_state();
+        let app = build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/submit")
+                    .header("content-type", "application/json")
+                    .body(Body::from("not json!!!"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let data: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(data["error"].as_str().unwrap(), "INVALID_JSON");
+        assert!(data["message"].is_string());
+    }
+
+    #[tokio::test]
+    async fn submit_missing_content_type_returns_400() {
+        let (state, _dir) = make_state();
+        let app = build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/submit")
+                    .body(Body::from(r#"{"payload":{}}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let data: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(data["error"].as_str().unwrap(), "INVALID_JSON");
+    }
+
+    #[tokio::test]
+    async fn submit_schema_violation_returns_422() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = Arc::new(HttpState {
+            data_dir: Arc::new(dir.path().to_path_buf()),
+            raw_key: None,
+            node_id: NodeId(1),
+            schema: PayloadSchema::JsonRequired(vec!["patient_id".to_string()]),
+            started_at: Instant::now(),
+        });
+        let app = build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/submit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"payload":{"name":"John"}}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let data: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(data["error"].as_str().unwrap(), "SCHEMA_VIOLATION");
+        assert!(
+            data["message"].as_str().unwrap().contains("patient_id"),
+            "message should mention the missing field, got: {}",
+            data["message"]
+        );
+    }
+
+    #[tokio::test]
+    async fn submit_valid_payload_returns_200() {
+        let (state, _dir) = make_state();
+        let app = build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/submit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"payload":{"x":1}}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let data: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(data["seq"].is_number());
+        assert!(data["node_id"].is_string());
+    }
+
+    #[tokio::test]
+    async fn error_response_always_has_error_and_message_fields() {
+        let (state, _dir) = make_state();
+        let app = build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/submit")
+                    .header("content-type", "application/json")
+                    .body(Body::from("{bad}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let data: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(data["error"].is_string(), "error field must be present");
+        assert!(data["message"].is_string(), "message field must be present");
+    }
+
+    #[tokio::test]
+    async fn submit_with_all_fields_returns_200() {
+        let (state, _dir) = make_state();
+        let app = build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/submit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"event_type":2,"payload":{"patient_id":"P-999","type":"discharge"}}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let data: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(data["seq"].is_number(), "seq must be present");
+        assert!(data["node_id"].is_string(), "node_id must be present");
     }
 }


### PR DESCRIPTION
## Summary

- Replace opaque `AppError(String)` with a typed enum mapping each failure to a stable machine-readable JSON code
- Add GitHub Pages documentation built with mdBook (same framework as rust-analyzer.github.io)
- 128 tests pass (6 new error-code tests)

## Error codes

All HTTP error responses now return a consistent JSON shape:

```json
{ "error": "SCHEMA_VIOLATION", "message": "missing required field: patient_id" }
```

| Code | HTTP | When |
|------|------|------|
| `INVALID_JSON` | 400 | Malformed body or missing `Content-Type: application/json` |
| `SCHEMA_VIOLATION` | 422 | Payload fails `--schema` validation |
| `WAL_UNAVAILABLE` | 503 | Disk/WAL IO failure |
| `INTERNAL_ERROR` | 500 | Unexpected bug |

The `submit` handler now uses axum `JsonRejection` to intercept parse errors before they become the default extractor's opaque 422.

## Docs (mdBook)

- `docs/book.toml` -- mdBook config, ayu dark theme, links to GitHub
- `docs/src/introduction.md` -- project overview + quick start
- `docs/src/rest-api.md` -- all endpoints with request/response examples
- `docs/src/error-codes.md` -- full error reference with retry patterns
- `.github/workflows/pages.yml` -- builds on push to main, deploys to GitHub Pages

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` -- 128 passed, 0 failed
- [x] `mdbook build docs` -- builds cleanly
- [x] 400 on malformed JSON body
- [x] 400 on missing Content-Type
- [x] 422 on schema violation (missing required field in message)
- [x] 200 on valid payload, seq + node_id present
- [x] Error response always has both `error` and `message` fields