### PR TITLE
chore: add all-contributors config

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,11 @@
+{
+  "projectName": "ZamSync",
+  "projectOwner": "Etoile-Bleu",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": ["CONTRIBUTORS.md"],
+  "imageSize": 100,
+  "commit": true,
+  "contributors": [],
+  "contributorsPerLine": 7
+}

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,6 @@
+# Contributors
+
+Thanks to these wonderful people!
+
+<!-- ALL-CONTRIBUTORS-LIST:START -->
+<!-- ALL-CONTRIBUTORS-LIST:END -->


### PR DESCRIPTION
Adds the two files needed for the all-contributors bot:

- `.all-contributorsrc` -- bot config (repo, owner, 7 per line)
- `CONTRIBUTORS.md` -- placeholder with the HTML comment anchors the bot writes into

Once merged, adding a contributor is just a comment on any PR or issue:

```
@all-contributors please add @KairosOps for code
```

The bot opens a PR automatically.