### PR TITLE
chore: populate all-contributors

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -6,6 +6,28 @@
   "files": ["CONTRIBUTORS.md"],
   "imageSize": 100,
   "commit": true,
-  "contributors": [],
+  "contributors": [
+    {
+      "login": "Etoile-Bleu",
+      "name": "Etoile-Bleu",
+      "avatar_url": "https://avatars.githubusercontent.com/u/56513031?v=4",
+      "profile": "https://github.com/Etoile-Bleu",
+      "contributions": ["code"]
+    },
+    {
+      "login": "KairosOps",
+      "name": "KairosOps",
+      "avatar_url": "https://avatars.githubusercontent.com/u/186839917?v=4",
+      "profile": "https://github.com/KairosOps",
+      "contributions": ["code", "bug"]
+    },
+    {
+      "login": "tyleruploads",
+      "name": "tyleruploads",
+      "avatar_url": "https://avatars.githubusercontent.com/u/242097429?v=4",
+      "profile": "https://github.com/tyleruploads",
+      "contributions": ["legal"]
+    }
+  ],
   "contributorsPerLine": 7
 }

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,5 +2,19 @@
 
 Thanks to these wonderful people!
 
-<!-- ALL-CONTRIBUTORS-LIST:START -->
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/Etoile-Bleu"><img src="https://avatars.githubusercontent.com/u/56513031?v=4?s=100" width="100px;" alt="Etoile-Bleu"/><br /><sub><b>Etoile-Bleu</b></sub></a><br /><a href="https://github.com/Etoile-Bleu/ZamSync/commits?author=Etoile-Bleu" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/KairosOps"><img src="https://avatars.githubusercontent.com/u/186839917?v=4?s=100" width="100px;" alt="KairosOps"/><br /><sub><b>KairosOps</b></sub></a><br /><a href="https://github.com/Etoile-Bleu/ZamSync/commits?author=KairosOps" title="Code">💻</a> <a href="https://github.com/Etoile-Bleu/ZamSync/issues?q=author%3AKairosOps" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/tyleruploads"><img src="https://avatars.githubusercontent.com/u/242097429?v=4?s=100" width="100px;" alt="tyleruploads"/><br /><sub><b>tyleruploads</b></sub></a><br /><a href="#legal-tyleruploads" title="Legal">⚖️</a></td>
+    </tr>
+  </tbody>
+</table>
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->


### PR DESCRIPTION
Adds all 3 contributors to `.all-contributorsrc` and generates the `CONTRIBUTORS.md` table.

| Contributor | Contribution |
|---|---|
| @Etoile-Bleu | 💻 code (192 commits, main author) |
| @KairosOps | 💻 code + 🐛 bug (Windows SQLite path fix, PR #93) |
| @tyleruploads | ⚖️ legal (MIT LICENSE) |