### PR TITLE
chore: fix all-contributors bot for branch protection

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -5,7 +5,7 @@
   "repoHost": "https://github.com",
   "files": ["CONTRIBUTORS.md"],
   "imageSize": 100,
-  "commit": true,
+  "commit": false,
   "contributors": [
     {
       "login": "Etoile-Bleu",


### PR DESCRIPTION
`commit: true` causes the bot to push directly to `main`, which is blocked by branch protection rules (CI required). Switching to `commit: false` makes the bot create a PR instead, which goes through CI normally.