### PR TITLE
chore: add light89219 as contributor

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -22,6 +22,13 @@
       "contributions": ["code", "bug"]
     },
     {
+      "login": "light89219",
+      "name": "light89219",
+      "avatar_url": "https://avatars.githubusercontent.com/u/175686159?v=4",
+      "profile": "https://github.com/light89219",
+      "contributions": ["code"]
+    },
+    {
       "login": "tyleruploads",
       "name": "tyleruploads",
       "avatar_url": "https://avatars.githubusercontent.com/u/242097429?v=4",

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,6 +10,7 @@ Thanks to these wonderful people!
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Etoile-Bleu"><img src="https://avatars.githubusercontent.com/u/56513031?v=4?s=100" width="100px;" alt="Etoile-Bleu"/><br /><sub><b>Etoile-Bleu</b></sub></a><br /><a href="https://github.com/Etoile-Bleu/ZamSync/commits?author=Etoile-Bleu" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/KairosOps"><img src="https://avatars.githubusercontent.com/u/186839917?v=4?s=100" width="100px;" alt="KairosOps"/><br /><sub><b>KairosOps</b></sub></a><br /><a href="https://github.com/Etoile-Bleu/ZamSync/commits?author=KairosOps" title="Code">💻</a> <a href="https://github.com/Etoile-Bleu/ZamSync/issues?q=author%3AKairosOps" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/light89219"><img src="https://avatars.githubusercontent.com/u/175686159?v=4?s=100" width="100px;" alt="light89219"/><br /><sub><b>light89219</b></sub></a><br /><a href="https://github.com/Etoile-Bleu/ZamSync/commits?author=light89219" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/tyleruploads"><img src="https://avatars.githubusercontent.com/u/242097429?v=4?s=100" width="100px;" alt="tyleruploads"/><br /><sub><b>tyleruploads</b></sub></a><br /><a href="#legal-tyleruploads" title="Legal">⚖️</a></td>
     </tr>
   </tbody>


### PR DESCRIPTION
Adds @light89219 to CONTRIBUTORS.md and .all-contributorsrc for their PostgreSQL projection contribution (PR #97). Done manually because the all-contributors bot is currently returning an error, see issue #105.