### PR TITLE
feat: add zamsync ping command

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -8,3 +8,9 @@
 
 - [REST API](rest-api.md)
 - [Error Codes](error-codes.md)
+
+---
+
+# CLI Reference
+
+- [ping](cli-ping.md)

--- a/docs/src/cli-ping.md
+++ b/docs/src/cli-ping.md
@@ -1,0 +1,121 @@
+# CLI -- ping
+
+`zamsync ping` probes a peer node by exchanging a single Handshake round-trip.
+It is the fastest way to verify that a hub is reachable and responding with a
+valid identity -- without opening the local WAL or running a full sync.
+
+```bash
+zamsync ping <data-dir> <peer-addr> [--tls] [--count N] [--timeout MS]
+```
+
+---
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--tls` | off | Use mTLS with credentials in `<data-dir>/tls/` |
+| `--count N` | `3` | Number of probes to send |
+| `--timeout MS` | `5000` | Per-probe timeout in milliseconds |
+
+---
+
+## Examples
+
+### Plain TCP ping
+
+```bash
+zamsync ping ./clinic1 192.168.1.100:9000
+```
+
+```
+PING 192.168.1.100:9000  local-node=1084291732
+  seq=1  peer=3782019481  rtt=42ms
+  seq=2  peer=3782019481  rtt=39ms
+  seq=3  peer=3782019481  rtt=44ms
+---
+3/3  loss=0%
+rtt  min=39ms  avg=41ms  max=44ms
+```
+
+### mTLS ping
+
+```bash
+zamsync ping ./clinic1 192.168.1.100:9000 --tls
+```
+
+```
+PING 192.168.1.100:9000  local-node=1084291732  [TLS]
+  seq=1  peer=3782019481  rtt=118ms  tls=ok
+  seq=2  peer=3782019481  rtt=112ms  tls=ok
+  seq=3  peer=3782019481  rtt=115ms  tls=ok
+---
+3/3  loss=0%
+rtt  min=112ms  avg=115ms  max=118ms
+```
+
+The higher RTT compared to plain TCP is the TLS handshake overhead -- normal on
+first connection. `tls=ok` confirms mutual authentication succeeded.
+
+### Single probe (scripting)
+
+```bash
+zamsync ping ./clinic1 192.168.1.100:9000 --count 1 --tls
+echo "exit: $?"   # 0 = reachable, 1 = unreachable
+```
+
+`ping` exits with code `1` if **all** probes fail, making it safe to use in
+shell scripts and systemd `ExecStartPre` checks.
+
+---
+
+## Output fields
+
+| Field | Meaning |
+|-------|---------|
+| `local-node` | This node's ID (from `<data-dir>/.node_id`) |
+| `peer` | Remote node's ID, extracted from the Handshake response |
+| `rtt` | Round-trip time including TCP connect + (TLS handshake) + Handshake exchange |
+| `tls=ok` | Mutual TLS handshake completed; both certificates are valid and trusted |
+| `loss` | Percentage of probes that did not receive a response within `--timeout` |
+
+---
+
+## What ping measures
+
+The RTT covers the full cost of establishing a sync connection:
+
+1. TCP three-way handshake
+2. TLS mutual handshake (if `--tls`)
+3. ZamSync `Handshake` message sent and acknowledged by the peer
+
+This is intentional: it tells you the real overhead a clinic pays before any
+event data is transferred.
+
+---
+
+## WAL and certificate requirements
+
+`ping` reads only two things from `<data-dir>`:
+
+- `.node_id` -- the local node's identity (created automatically if absent)
+- `tls/` -- TLS credentials (only when `--tls` is passed)
+
+The WAL is **not opened**. `ping` works even if the WAL is locked by a running
+`serve` or `daemon` process.
+
+---
+
+## Typical field workflow
+
+```bash
+# 1. Check that the hub is reachable over mTLS before triggering a sync
+zamsync ping ./clinic1 192.168.1.100:9000 --tls --count 1 && \
+  zamsync sync ./clinic1 192.168.1.100:9000 3782019481 --tls
+
+# 2. Diagnose latency before a large sync (2G link)
+zamsync ping ./clinic1 192.168.1.100:9000 --tls --count 10 --timeout 10000
+
+# 3. Systemd health check before starting the daemon
+ExecStartPre=zamsync ping /var/lib/zamsync/clinic1 hub.local:9000 --tls --count 1
+```

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -35,6 +35,7 @@ open http://localhost:8080/ui
 
 - [REST API](rest-api.md) -- all endpoints with request/response examples
 - [Error Codes](error-codes.md) -- structured error reference for client developers
+- [ping](cli-ping.md) -- check hub reachability and RTT from the command line
 
 ## Source
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -5,6 +5,7 @@ mod daemon;
 pub(crate) mod expire;
 mod info;
 mod keygen;
+mod ping;
 mod project;
 mod project_pg;
 mod rekey;
@@ -21,6 +22,7 @@ pub use daemon::run as daemon;
 pub use expire::run as expire;
 pub use info::run as info;
 pub use keygen::run as keygen;
+pub use ping::run as ping;
 pub use project::run as project;
 pub use rekey::run as rekey;
 pub use serve::run as serve;
@@ -37,6 +39,7 @@ pub fn usage() {
   zamsync sync    <data-dir> <peer-addr> <peer-id> [--tls] [--schema ..] [--metrics <addr>]
   zamsync serve   <data-dir> <bind-addr> [--tls] [--schema ..] [--policy all|own] [--metrics <addr>] [--http <addr>]
   zamsync daemon  <data-dir> <peer-addr> <peer-id> [--tls] [--schema ..] [--interval <secs>] [--metrics <addr>]
+  zamsync ping    <data-dir> <peer-addr> [--tls] [--count N] [--timeout MS]
   zamsync compact <data-dir>
   zamsync keygen  <data-dir>
   zamsync sign    <clinic-dir> --ca <hub-dir>

--- a/src/cmd/ping.rs
+++ b/src/cmd/ping.rs
@@ -1,0 +1,132 @@
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use zamsync_core::ports::Transport;
+use zamsync_core::{NodeId, SyncMessage, VersionVector};
+use zamsync_network::{TcpTransport, TlsTcpTransport};
+
+use crate::util::{data_dir, flag_value, load_tls_config, node_id_from_dir};
+
+const DEFAULT_COUNT: usize = 3;
+const DEFAULT_TIMEOUT_MS: u64 = 5_000;
+
+// Placeholder key used while the remote node's real ID is unknown.
+// The actual peer NodeId is extracted from the Handshake message payload.
+const PROBE_PEER: NodeId = NodeId(0);
+
+pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
+    let dir = data_dir(args, 2)?;
+    let peer_addr = args
+        .get(3)
+        .ok_or("usage: zamsync ping <data-dir> <peer-addr> [--tls] [--count N] [--timeout MS]")?;
+    let use_tls = args.contains(&"--tls".to_string());
+    let count: usize = flag_value(args, "--count")
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_COUNT);
+    let timeout = Duration::from_millis(
+        flag_value(args, "--timeout")
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(DEFAULT_TIMEOUT_MS),
+    );
+
+    let local_id = node_id_from_dir(&dir);
+    let tls_tag = if use_tls { "  [TLS]" } else { "" };
+    println!("PING {peer_addr}  local-node={}{tls_tag}", local_id.0);
+
+    let mut rtt_samples: Vec<Duration> = Vec::with_capacity(count);
+    let mut failures = 0usize;
+
+    for seq in 1..=count {
+        match probe(&dir, local_id, peer_addr, use_tls, timeout) {
+            Ok((peer_id, rtt)) => {
+                let ok_tag = if use_tls { "  tls=ok" } else { "" };
+                println!(
+                    "  seq={seq}  peer={}  rtt={}ms{ok_tag}",
+                    peer_id.0,
+                    rtt.as_millis()
+                );
+                rtt_samples.push(rtt);
+            }
+            Err(e) => {
+                println!("  seq={seq}  error: {e}");
+                failures += 1;
+            }
+        }
+    }
+
+    println!("---");
+    let successes = count - failures;
+    let loss_pct = (failures * 100) / count;
+    println!("{successes}/{count}  loss={loss_pct}%");
+    if !rtt_samples.is_empty() {
+        let min = rtt_samples.iter().min().unwrap().as_millis();
+        let max = rtt_samples.iter().max().unwrap().as_millis();
+        let avg =
+            rtt_samples.iter().map(|d| d.as_millis()).sum::<u128>() / rtt_samples.len() as u128;
+        println!("rtt  min={min}ms  avg={avg}ms  max={max}ms");
+    }
+
+    if failures == count {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+/// Establishes one probe connection, exchanges a Handshake, and returns the
+/// remote node's ID with the round-trip time (connection setup included).
+fn probe(
+    dir: &Path,
+    local_id: NodeId,
+    peer_addr: &str,
+    use_tls: bool,
+    timeout: Duration,
+) -> Result<(NodeId, Duration), Box<dyn std::error::Error>> {
+    let t0 = Instant::now();
+    if use_tls {
+        let tls_config = load_tls_config(dir)?;
+        let mut transport = TlsTcpTransport::bind("0.0.0.0:0", &tls_config)?;
+        transport.connect(PROBE_PEER, peer_addr)?;
+        send_handshake(&mut transport, local_id)?;
+        recv_handshake(&mut transport, t0, timeout)
+    } else {
+        let mut transport = TcpTransport::bind("0.0.0.0:0")?;
+        transport.connect(PROBE_PEER, peer_addr)?;
+        send_handshake(&mut transport, local_id)?;
+        recv_handshake(&mut transport, t0, timeout)
+    }
+}
+
+fn send_handshake<T: Transport>(
+    transport: &mut T,
+    local_id: NodeId,
+) -> Result<(), Box<dyn std::error::Error>> {
+    transport.send(
+        PROBE_PEER,
+        &SyncMessage::Handshake {
+            node_id: local_id,
+            vv: VersionVector::new(),
+        },
+    )?;
+    Ok(())
+}
+
+/// Polls until the peer's Handshake arrives or the deadline expires.
+/// The NodeId is read from the message payload, not the connection key.
+fn recv_handshake<T: Transport>(
+    transport: &mut T,
+    t0: Instant,
+    timeout: Duration,
+) -> Result<(NodeId, Duration), Box<dyn std::error::Error>> {
+    loop {
+        if t0.elapsed() > timeout {
+            return Err(format!("timeout after {}ms", timeout.as_millis()).into());
+        }
+        match transport.receive()? {
+            Some((_, SyncMessage::Handshake { node_id, .. })) => {
+                return Ok((node_id, t0.elapsed()));
+            }
+            Some(_) => {}
+            None => std::thread::sleep(Duration::from_millis(5)),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Some("rekey") => cmd::rekey(&args),
         Some("bench") => cmd::bench(&args),
         Some("daemon") => cmd::daemon(&args),
+        Some("ping") => cmd::ping(&args),
         Some("audit") => cmd::audit(&args),
         Some("project") => cmd::project(&args),
         Some("expire") => cmd::expire(&args),


### PR DESCRIPTION
## Summary

- Adds `zamsync ping <data-dir> <peer-addr> [--tls] [--count N] [--timeout MS]` -- a lightweight connectivity probe that exchanges a single Handshake round-trip without opening the WAL
- Discovers the remote node ID from the Handshake response and reports RTT per probe with min/avg/max summary
- Works with both plain TCP and mTLS (`--tls`); exits with code 1 if all probes fail (safe for scripting and systemd `ExecStartPre`)
- Adds a full CLI reference page to GitHub Pages (`docs/src/cli-ping.md`) with flag table, output examples, and a field workflow section
- Zero new dependencies

## Test plan

- [ ] `cargo fmt --all` and `cargo clippy --workspace --all-targets -- -D warnings` pass clean
- [ ] `cargo test --workspace` -- all tests green
- [ ] Manual: start a hub with `zamsync serve`, run `zamsync ping` against it (plain TCP and `--tls`), verify peer node ID and RTT are printed correctly
- [ ] Manual: ping an unreachable address, verify error output and exit code 1
- [ ] GitHub Pages: verify `cli-ping.md` renders correctly under the CLI Reference section
