### PR TITLE
fix(release): generate changelog only from previous tag

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -168,6 +168,10 @@ jobs:
       contents: write
 
     steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
       - uses: actions/download-artifact@v8
         with:
           path: dist/
@@ -183,50 +187,78 @@ jobs:
           sha256sum * > SHA256SUMS.txt
           cat SHA256SUMS.txt
 
+      - name: Build release body
+        run: |
+          git fetch --tags
+
+          # Find the closest previous semver tag, excluding the current one.
+          # This is the fix for the "Full Changelog: v1.1.1...v1.3.1" bug where
+          # GitHub's auto-generator picks the wrong base because the tag is
+          # created from a side branch before the PR is merged.
+          PREV=$(git tag --sort=-version:refname \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | grep -v "^${{ env.RELEASE_TAG }}$" \
+            | head -1)
+          echo "Generating changelog from $PREV to ${{ env.RELEASE_TAG }}"
+
+          REPO="${{ github.repository }}"
+          TAG="${{ env.RELEASE_TAG }}"
+          REPO_LOWER=$(echo "$REPO" | tr '[:upper:]' '[:lower:]')
+
+          # Write static install block
+          cat > /tmp/release_body.md << EOF
+          Offline-first synchronization engine for intermittent-connectivity deployments.
+
+          ### Install
+
+          \`\`\`bash
+          # Linux x86_64
+          curl -fsSL -o zamsync https://github.com/${REPO}/releases/download/${TAG}/zamsync-linux-x86_64
+          chmod +x zamsync && sudo mv zamsync /usr/local/bin/
+
+          # Linux ARM64 (Raspberry Pi 4, AWS Graviton)
+          curl -fsSL -o zamsync https://github.com/${REPO}/releases/download/${TAG}/zamsync-linux-aarch64
+          chmod +x zamsync && sudo mv zamsync /usr/local/bin/
+
+          # Linux ARMv7 (Raspberry Pi 2 / 3)
+          curl -fsSL -o zamsync https://github.com/${REPO}/releases/download/${TAG}/zamsync-linux-armv7
+          chmod +x zamsync && sudo mv zamsync /usr/local/bin/
+
+          # Windows (PowerShell)
+          Invoke-WebRequest -Uri "https://github.com/${REPO}/releases/download/${TAG}/zamsync-windows-x86_64.exe" -OutFile zamsync.exe
+          \`\`\`
+
+          ### Docker
+
+          \`\`\`bash
+          docker pull ghcr.io/${REPO_LOWER}:${TAG}
+          # or latest
+          docker pull ghcr.io/${REPO_LOWER}:latest
+          \`\`\`
+
+          ### Verify checksums
+
+          \`\`\`bash
+          sha256sum -c SHA256SUMS.txt
+          \`\`\`
+
+          EOF
+
+          # Append delta changelog (only commits since $PREV, not the full history)
+          gh api repos/${REPO}/releases/generate-notes \
+            -f tag_name="${TAG}" \
+            -f previous_tag_name="${PREV}" \
+            --jq '.body' >> /tmp/release_body.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ env.RELEASE_TAG }}
           name: "ZamSync ${{ env.RELEASE_TAG }}"
-          body: |
-            ## ZamSync ${{ env.RELEASE_TAG }}
-
-            Offline-first synchronization engine for intermittent-connectivity deployments.
-
-            ### Install
-
-            ```bash
-            # Linux x86_64
-            curl -fsSL -o zamsync https://github.com/${{ github.repository }}/releases/download/${{ env.RELEASE_TAG }}/zamsync-linux-x86_64
-            chmod +x zamsync && sudo mv zamsync /usr/local/bin/
-
-            # Linux ARM64 (Raspberry Pi 4, AWS Graviton)
-            curl -fsSL -o zamsync https://github.com/${{ github.repository }}/releases/download/${{ env.RELEASE_TAG }}/zamsync-linux-aarch64
-            chmod +x zamsync && sudo mv zamsync /usr/local/bin/
-
-            # Linux ARMv7 (Raspberry Pi 2 / 3)
-            curl -fsSL -o zamsync https://github.com/${{ github.repository }}/releases/download/${{ env.RELEASE_TAG }}/zamsync-linux-armv7
-            chmod +x zamsync && sudo mv zamsync /usr/local/bin/
-
-            # Windows (PowerShell)
-            Invoke-WebRequest -Uri "https://github.com/${{ github.repository }}/releases/download/${{ env.RELEASE_TAG }}/zamsync-windows-x86_64.exe" -OutFile zamsync.exe
-            ```
-
-            ### Docker
-
-            ```bash
-            docker pull ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]'):${{ env.RELEASE_TAG }}
-            # or latest
-            docker pull ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]'):latest
-            ```
-
-            ### Verify checksums
-
-            ```bash
-            sha256sum -c SHA256SUMS.txt
-            ```
+          body_path: /tmp/release_body.md
           files: |
             release/*
-          generate_release_notes: true
           fail_on_unmatched_files: true
 
   # ── Smoke tests -- verify the binary and Docker image actually work ───────────


### PR DESCRIPTION
## Problem

The "What's Changed" section in each release was listing all commits since v1.1.1 instead of just the commits since the previous release. The root cause: `generate_release_notes: true` lets GitHub auto-detect the previous release by walking the commit graph from the tag ref. Because the tag is created from a side branch (`chore/bump-vX.Y.Z`) before the PR is merged, GitHub can't find the correct previous release in the ancestry and falls back to an older one.

## Fix

- Add a checkout step with `fetch-depth: 0` to get all tags
- Find the previous semver tag explicitly with `git tag --sort=-version:refname`
- Call the GitHub `generate-notes` API with `previous_tag_name` set explicitly
- Write the static install block + delta changelog to a file, passed to softprops via `body_path`
- Remove `generate_release_notes: true` (replaced by the explicit API call)

## Result

Next release will show only the commits since the immediately preceding tag, regardless of which branch the tag was created from.
