### PR TITLE
feat(cli): add color output to all commands

### DIFF
--- a/src/cmd/audit.rs
+++ b/src/cmd/audit.rs
@@ -1,3 +1,4 @@
+use crate::color;
 use crate::util::{data_dir, flag_value, load_encryption_key, node_id_from_dir, open_engine};
 use sha2::{Digest, Sha256};
 use zamsync_storage::PayloadSchema;
@@ -14,10 +15,15 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
 
     if format == "text" {
         println!(
-            "{:<27} {:>10} {:>10} {:>6} {:>8}  sha256",
-            "timestamp", "node", "seq", "type", "size"
+            "{}",
+            color::bold(&format!(
+                "{:<27} {:>10} {:>10} {:>6} {:>8}  sha256",
+                "timestamp", "node", "seq", "type", "size"
+            ))
         );
-        println!("{}", "-".repeat(90));
+        println!("{}", color::dim(&"-".repeat(90)));
+    } else if format == "csv" {
+        println!("timestamp,node,seq,type,size_bytes,sha256");
     }
 
     let mut total = 0usize;
@@ -48,22 +54,31 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
                 event.payload.len(),
                 event.hlc.logical,
             ),
-            _ => println!(
-                "{:<27} {:>10} {:>10} {:>6} {:>8}  {}",
+            "csv" => println!(
+                "{},{},{},{},{},{}",
                 ts,
                 event.origin_node.0,
                 event.seq.0,
                 event.event_type,
                 event.payload.len(),
-                &hash[..16],
+                hash,
+            ),
+            _ => println!(
+                "{}  {:>10}  {:>10}  {:>6}  {:>8}  {}",
+                color::dim(&ts),
+                event.origin_node.0,
+                event.seq.0,
+                event.event_type,
+                event.payload.len(),
+                color::dim(&hash[..16]),
             ),
         }
         total += 1;
     }
 
     if format == "text" {
-        println!("{}", "-".repeat(90));
-        println!("{total} event(s)");
+        println!("{}", color::dim(&"-".repeat(90)));
+        println!("{} event(s)", color::bold(&total.to_string()));
     }
 
     Ok(())

--- a/src/cmd/daemon.rs
+++ b/src/cmd/daemon.rs
@@ -1,3 +1,4 @@
+use crate::color;
 use crate::metrics::start_metrics_server;
 use crate::util::{
     data_dir, flag_value, load_encryption_key, load_schema, load_tls_config, node_id_from_dir,
@@ -25,11 +26,15 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     let node_id = node_id_from_dir(&dir);
     let peer = NodeId(peer_id);
     let interval = Duration::from_secs(interval_secs);
-
     let mode = if use_tls { "TLS" } else { "TCP" };
+
     println!(
-        "daemon: node {} syncing with peer {} ({}) every {}s",
-        node_id.0, peer_id, mode, interval_secs
+        "{} node {} -- peer {} ({}) -- interval {}s",
+        color::bold("daemon:"),
+        node_id.0,
+        peer_id,
+        mode,
+        interval_secs,
     );
 
     loop {
@@ -46,14 +51,22 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
             Ok((sent, received)) => {
                 if sent > 0 || received > 0 {
                     println!(
-                        "[sync] peer={} sent={} received={}",
-                        peer_id, sent, received
+                        "{} peer={}  sent={}  received={}",
+                        color::green("[sync]"),
+                        peer_id,
+                        sent,
+                        received,
                     );
                 } else {
-                    println!("[sync] peer={} already in sync", peer_id);
+                    println!("{} peer={}  already in sync", color::dim("[sync]"), peer_id,);
                 }
             }
-            Err(e) => eprintln!("[sync] peer={} error: {}", peer_id, e),
+            Err(e) => eprintln!(
+                "{} peer={}  {}",
+                color::red("[sync]"),
+                peer_id,
+                color::red(&format!("error: {e}")),
+            ),
         }
 
         let elapsed = tick_start.elapsed();

--- a/src/cmd/expire.rs
+++ b/src/cmd/expire.rs
@@ -1,3 +1,4 @@
+use crate::color;
 use crate::util::{
     data_dir, flag_value, load_encryption_key, load_schema, node_id_from_dir, open_engine,
 };
@@ -28,12 +29,17 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
                 payload_bytes += event.payload.len() as u64;
             }
         }
-        println!("dry-run  : {} events would be expired", would_drop);
         println!(
-            "payload  : {} KB in expirable payloads",
-            payload_bytes / 1024
+            "{}  {} events would be expired",
+            color::dim("dry-run  :"),
+            color::yellow(&would_drop.to_string()),
         );
-        println!("wal size : {} KB", wal_size / 1024);
+        println!(
+            "{}  {} KB in expirable payloads",
+            color::dim("payload  :"),
+            payload_bytes / 1024,
+        );
+        println!("{}  {} KB", color::dim("wal size :"), wal_size / 1024);
         return Ok(());
     }
 
@@ -42,12 +48,17 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     engine.sync()?;
 
     if dropped == 0 {
-        println!("expire   : nothing to drop (all events newer than cutoff)");
+        println!(
+            "{}  {}",
+            color::dim("expire   :"),
+            color::green("nothing to drop (all events newer than cutoff)"),
+        );
     } else {
         println!(
-            "expire   : dropped {} events, freed {} KB",
-            dropped,
-            bytes_freed / 1024
+            "{}  dropped {} events, freed {} KB",
+            color::dim("expire   :"),
+            color::yellow(&dropped.to_string()),
+            bytes_freed / 1024,
         );
     }
     Ok(())

--- a/src/cmd/info.rs
+++ b/src/cmd/info.rs
@@ -1,3 +1,4 @@
+use crate::color;
 use crate::util::{data_dir, flag_value, format_date, load_encryption_key, node_id_from_dir};
 use std::collections::BTreeMap;
 use zamsync_core::{ports::StateStore, Event, SequenceNumber, ZamResult};
@@ -25,6 +26,13 @@ impl StateStore for InfoState {
     }
 }
 
+/// Print a labeled field: dim label, normal value.
+macro_rules! field {
+    ($label:expr, $value:expr) => {
+        println!("{}  {}", color::dim($label), $value)
+    };
+}
+
 pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     let dir = data_dir(args, 2)?;
     let node_id = node_id_from_dir(&dir);
@@ -35,37 +43,44 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
         None => ZamEngine::open_wal(&dir, node_id, InfoState::default())?,
     };
 
-    println!("node_id  : {}", node_id.0);
-    println!("data_dir : {}", dir.display());
-    println!("events   : {}", engine.state().count);
+    field!("node_id  :", &color::bold(&node_id.0.to_string()));
+    field!("data_dir :", &dir.display().to_string());
+
+    let count = engine.state().count;
+    let count_str = if count > 0 {
+        color::bold(&count.to_string())
+    } else {
+        color::dim("0")
+    };
+    field!("events   :", &count_str);
 
     let vv = &engine.replication_state().local_vv;
     if vv.entries.is_empty() {
-        println!("vv       : (empty)");
+        field!("vv       :", &color::dim("(empty)"));
     } else {
         for (node, seq) in &vv.entries {
-            println!("vv       : node {} @ seq {}", node, seq.0);
+            field!("vv       :", &format!("node {} @ seq {}", node, seq.0));
         }
     }
 
     let wal_kb = std::fs::metadata(dir.join("events.wal"))
         .map(|m| m.len() / 1024)
         .unwrap_or(0);
-    println!("wal size : {} KB", wal_kb);
+    field!("wal size :", &format!("{wal_kb} KB"));
 
     match (engine.state().oldest_ms, engine.state().newest_ms) {
         (Some(o), Some(n)) => {
-            println!("oldest   : {}", format_date(o));
-            println!("newest   : {}", format_date(n));
+            field!("oldest   :", &format_date(o));
+            field!("newest   :", &format_date(n));
         }
         _ => {
-            println!("oldest   : --");
-            println!("newest   : --");
+            field!("oldest   :", &color::dim("--"));
+            field!("newest   :", &color::dim("--"));
         }
     }
 
     if let Some(retain) = flag_value(args, "--retain") {
-        println!("retain   : {}", retain);
+        field!("retain   :", retain);
     }
 
     let mut peer_counts: BTreeMap<u32, u64> = BTreeMap::new();
@@ -75,15 +90,24 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     for (&node, &count) in &engine.state().per_node {
         *peer_counts.entry(node).or_insert(0) = count;
     }
+
     if peer_counts.is_empty() {
-        println!("peers    : (none)");
+        field!("peers    :", &color::dim("(none)"));
     } else {
-        println!("peers:");
+        println!("{}  peers:", color::dim("         "));
         for (node, count) in &peer_counts {
             if *count == 0 {
-                println!("  node {:<6}: 0 events  (in VV but no local events)", node);
+                println!(
+                    "    node {:<6}  {}",
+                    node,
+                    color::dim("0 events  (in VV but no local events)"),
+                );
             } else {
-                println!("  node {:<6}: {} events", node, count);
+                println!(
+                    "    node {:<6}  {} events",
+                    node,
+                    color::bold(&count.to_string())
+                );
             }
         }
     }

--- a/src/cmd/keygen.rs
+++ b/src/cmd/keygen.rs
@@ -1,3 +1,4 @@
+use crate::color;
 use crate::util::data_dir;
 use zamsync_network::generate_credentials;
 use zamsync_storage::EncryptionKey;
@@ -18,19 +19,45 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     let enc_key = EncryptionKey::generate()?;
     enc_key.to_file(tls_dir.join("data.key"))?;
 
-    println!("Credentials generated in {}/tls/", dir.display());
+    println!(
+        "{} {}/tls/",
+        color::green("credentials generated in"),
+        dir.display()
+    );
     println!();
-    println!("  === TLS (transport encryption) ===");
-    println!("  ca.crt   -- copy to all other nodes in this deployment");
-    println!("  ca.key   -- keep secret; only needed to sign new node certs");
-    println!("  node.crt -- this node's identity certificate");
-    println!("  node.key -- this node's private key (never share)");
+    println!("  {}", color::bold("=== TLS (transport encryption) ==="));
+    println!(
+        "  {}  copy to all other nodes in this deployment",
+        color::dim("ca.crt  --")
+    );
+    println!(
+        "  {}  keep secret; only needed to sign new node certs",
+        color::dim("ca.key  --")
+    );
+    println!(
+        "  {}  this node's identity certificate",
+        color::dim("node.crt--")
+    );
+    println!(
+        "  {}  this node's private key (never share)",
+        color::dim("node.key--")
+    );
     println!();
-    println!("  === WAL encryption (at-rest) ===");
-    println!("  data.key -- 32-byte random key for WAL encryption");
-    println!("              CRITICAL: store outside the data dir in production");
+    println!("  {}", color::bold("=== WAL encryption (at-rest) ==="));
+    println!(
+        "  {}  32-byte random key for WAL encryption",
+        color::dim("data.key--")
+    );
+    println!(
+        "              {}  store outside the data dir in production",
+        color::yellow("CRITICAL:"),
+    );
     println!("              Recommended: move to /etc/zamsync/data.key (chmod 600)");
     println!();
-    println!("Use '--tls' to encrypt transport, '--key-file <path>' to encrypt WAL.");
+    println!(
+        "Use {} to encrypt transport, {} to encrypt WAL.",
+        color::bold("--tls"),
+        color::bold("--key-file <path>"),
+    );
     Ok(())
 }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -45,7 +45,7 @@ pub fn usage() {
   zamsync sign    <clinic-dir> --ca <hub-dir>
   zamsync rekey   <data-dir> --old-key <path> --new-key <path>
   zamsync bench    <data-dir> [--events N]
-  zamsync audit    <data-dir> [--format json|text] [--since <unix-ms>] [--node <id>] [--key-file <path>]
+  zamsync audit    <data-dir> [--format json|text|csv] [--since <unix-ms>] [--node <id>] [--key-file <path>]
   zamsync project  <data-dir> [--target sqlite://path | postgres://...] [--batch-size N] [--dry-run] [--key-file <path>]
   zamsync expire   <data-dir> --before YYYY-MM-DD [--dry-run] [--min-keep N] [--key-file <path>]
   zamsync snapshot <data-dir> --output <path>
@@ -65,6 +65,11 @@ Flags (all commands that open the WAL):
 PKI workflow:
   zamsync keygen <hub-dir>                     -- generate hub CA + hub node cert + WAL key
   zamsync sign   <clinic-dir> --ca <hub-dir>   -- sign a new clinic node cert with hub CA
-  zamsync rekey  <dir> --old-key <p> --new-key <p>  -- rotate WAL encryption key"
+  zamsync rekey  <dir> --old-key <p> --new-key <p>  -- rotate WAL encryption key
+
+Color output (all commands):
+  --no-color         Disable ANSI colors
+  NO_COLOR=1         Disable ANSI colors (env, see no-color.org)
+  TERM=dumb          Disable ANSI colors (env)"
     );
 }

--- a/src/cmd/ping.rs
+++ b/src/cmd/ping.rs
@@ -5,6 +5,7 @@ use zamsync_core::ports::Transport;
 use zamsync_core::{NodeId, SyncMessage, VersionVector};
 use zamsync_network::{TcpTransport, TlsTcpTransport};
 
+use crate::color;
 use crate::util::{data_dir, flag_value, load_tls_config, node_id_from_dir};
 
 const DEFAULT_COUNT: usize = 3;
@@ -30,8 +31,17 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let local_id = node_id_from_dir(&dir);
-    let tls_tag = if use_tls { "  [TLS]" } else { "" };
-    println!("PING {peer_addr}  local-node={}{tls_tag}", local_id.0);
+    let tls_tag = if use_tls {
+        format!("  {}", color::green("[TLS]"))
+    } else {
+        String::new()
+    };
+    println!(
+        "{}  local-node={}{}",
+        color::bold(&format!("PING {peer_addr}")),
+        local_id.0,
+        tls_tag,
+    );
 
     let mut rtt_samples: Vec<Duration> = Vec::with_capacity(count);
     let mut failures = 0usize;
@@ -39,31 +49,46 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     for seq in 1..=count {
         match probe(&dir, local_id, peer_addr, use_tls, timeout) {
             Ok((peer_id, rtt)) => {
-                let ok_tag = if use_tls { "  tls=ok" } else { "" };
+                let rtt_ms = rtt.as_millis();
+                let tls_ok = if use_tls {
+                    format!("  {}", color::green("tls=ok"))
+                } else {
+                    String::new()
+                };
                 println!(
-                    "  seq={seq}  peer={}  rtt={}ms{ok_tag}",
+                    "  {}  peer={}  rtt={}{}",
+                    color::dim(&format!("seq={seq}")),
                     peer_id.0,
-                    rtt.as_millis()
+                    color::rtt(rtt_ms),
+                    tls_ok,
                 );
                 rtt_samples.push(rtt);
             }
             Err(e) => {
-                println!("  seq={seq}  error: {e}");
+                println!(
+                    "  {}  {}",
+                    color::dim(&format!("seq={seq}")),
+                    color::red(&format!("error: {e}")),
+                );
                 failures += 1;
             }
         }
     }
 
-    println!("---");
+    println!("{}", color::dim("---"));
     let successes = count - failures;
-    let loss_pct = (failures * 100) / count;
-    println!("{successes}/{count}  loss={loss_pct}%");
+    println!("{successes}/{count}  {}", color::loss(failures, count));
     if !rtt_samples.is_empty() {
         let min = rtt_samples.iter().min().unwrap().as_millis();
         let max = rtt_samples.iter().max().unwrap().as_millis();
         let avg =
             rtt_samples.iter().map(|d| d.as_millis()).sum::<u128>() / rtt_samples.len() as u128;
-        println!("rtt  min={min}ms  avg={avg}ms  max={max}ms");
+        println!(
+            "rtt  min={}  avg={}  max={}",
+            color::rtt(min),
+            color::rtt(avg),
+            color::rtt(max),
+        );
     }
 
     if failures == count {

--- a/src/cmd/project.rs
+++ b/src/cmd/project.rs
@@ -1,3 +1,4 @@
+use crate::color;
 use crate::util::{data_dir, flag_value, load_encryption_key, node_id_from_dir, open_engine};
 use rusqlite::{params, Connection};
 use std::path::{Path, PathBuf};
@@ -19,7 +20,11 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
         matches!(target, Some(u) if u.starts_with("postgres://") || u.starts_with("postgresql://"));
 
     if is_pg && dry_run {
-        eprintln!("[dry-run] would project to {}", target.unwrap());
+        eprintln!(
+            "{}  would project to {}",
+            color::dim("[dry-run]"),
+            target.unwrap()
+        );
     }
 
     let node_id = node_id_from_dir(&dir);
@@ -28,28 +33,35 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     if dry_run {
         if !is_pg {
             let db_path = resolve_db_path(args, &dir)?;
-            eprintln!("[dry-run] would project to {}", db_path.display());
+            eprintln!(
+                "{}  would project to {}",
+                color::dim("[dry-run]"),
+                db_path.display()
+            );
         }
         let mut projected = 0usize;
         for result in engine.sorted_scan()? {
             let event = result?;
             println!(
-                "node={} seq={} type={} size={}B hlc={}",
-                event.origin_node.0,
-                event.seq.0,
+                "{}  {}  type={}  {}",
+                color::dim(&format!("node={}", event.origin_node.0)),
+                color::dim(&format!("seq={}", event.seq.0)),
                 event.event_type,
-                event.payload.len(),
-                event.hlc.physical,
+                color::dim(&format!("size={}B", event.payload.len())),
             );
             projected += 1;
         }
-        println!("{projected} events would be projected");
+        println!(
+            "{}  {} events would be projected",
+            color::dim("[dry-run]"),
+            color::yellow(&projected.to_string()),
+        );
         return Ok(());
     }
 
     if is_pg {
         let url = target.unwrap();
-        println!("projecting to {url}");
+        println!("{}  {}", color::dim("projecting to"), url);
         let scan = engine.sorted_scan()?;
         let iter = scan
             .into_iter()
@@ -58,7 +70,7 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let db_path = resolve_db_path(args, &dir)?;
-    println!("projecting to {}", db_path.display());
+    println!("{}  {}", color::dim("projecting to"), db_path.display());
 
     let mut conn = Connection::open(&db_path)?;
     init_schema(&conn)?;
@@ -83,7 +95,12 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
         projected += p;
         skipped += s;
     }
-    println!("{projected} projected, {skipped} already present");
+    println!(
+        "{}  {} projected, {} already present",
+        color::dim("project  :"),
+        color::green(&projected.to_string()),
+        color::dim(&skipped.to_string()),
+    );
 
     Ok(())
 }

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -1,4 +1,5 @@
 use crate::cmd::expire::parse_retain_ms;
+use crate::color;
 use crate::http::HttpConfig;
 use crate::metrics::start_metrics_server;
 use crate::util::{
@@ -99,9 +100,10 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
                     Ok(mut eng) => match eng.expire_before(cutoff_ms, 0) {
                         Ok((dropped, freed)) if dropped > 0 => {
                             println!(
-                                "retain   : dropped {} events, freed {} KB",
-                                dropped,
-                                freed / 1024
+                                "{}  dropped {} events, freed {} KB",
+                                color::dim("retain   :"),
+                                color::yellow(&dropped.to_string()),
+                                freed / 1024,
                             );
                             let _ = eng.sync();
                         }
@@ -119,11 +121,11 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
         let tls_config = load_tls_config(&dir)?;
         let mut transport = TlsTcpTransport::bind(bind_addr, &tls_config)?;
         println!(
-            "node {} TLS listening on {} [policy={:?}] [max-peers={}]",
-            node_id.0,
-            transport.local_addr()?,
-            policy,
-            max_peers,
+            "{} {} {} {}",
+            color::bold(&format!("node {} TLS", node_id.0)),
+            color::green(&format!("listening on {}", transport.local_addr()?)),
+            color::dim(&format!("[policy={policy:?}]")),
+            color::dim(&format!("[max-peers={max_peers}]")),
         );
         tls_loop(
             node_id,
@@ -137,11 +139,10 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     } else {
         let mut transport = TcpTransport::bind(bind_addr)?;
         println!(
-            "node {} listening on {} [policy={:?}] [max-peers={}]",
-            node_id.0,
-            transport.local_addr()?,
-            policy,
-            max_peers,
+            "{} {} {}",
+            color::bold(&format!("node {}", node_id.0)),
+            color::green(&format!("listening on {}", transport.local_addr()?)),
+            color::dim(&format!("[policy={policy:?}] [max-peers={max_peers}]")),
         );
         tcp_loop(
             node_id,
@@ -208,10 +209,16 @@ fn serve_peer_tcp(
     };
     match SyncSession::new(&mut engine, &mut pt).serve_one(peer_id) {
         Ok(stats) => println!(
-            "peer {} done: sent={} received={}",
-            peer_id.0, stats.events_sent, stats.events_received
+            "{} {} sent={} received={}",
+            color::bold(&format!("peer {}", peer_id.0)),
+            color::green("done:"),
+            stats.events_sent,
+            stats.events_received,
         ),
-        Err(e) => eprintln!("peer {} sync error: {e}", peer_id.0),
+        Err(e) => eprintln!(
+            "{} sync error: {e}",
+            color::red(&format!("peer {}", peer_id.0))
+        ),
     }
 }
 
@@ -275,10 +282,16 @@ fn serve_peer_tls(
     };
     match SyncSession::new(&mut engine, &mut pt).serve_one(peer_id) {
         Ok(stats) => println!(
-            "TLS peer {} done: sent={} received={}",
-            peer_id.0, stats.events_sent, stats.events_received
+            "{} {} sent={} received={}",
+            color::bold(&format!("TLS peer {}", peer_id.0)),
+            color::green("done:"),
+            stats.events_sent,
+            stats.events_received,
         ),
-        Err(e) => eprintln!("TLS peer {} sync error: {e}", peer_id.0),
+        Err(e) => eprintln!(
+            "{} sync error: {e}",
+            color::red(&format!("TLS peer {}", peer_id.0)),
+        ),
     }
 }
 

--- a/src/cmd/sign.rs
+++ b/src/cmd/sign.rs
@@ -1,3 +1,4 @@
+use crate::color;
 use crate::util::{data_dir, flag_value};
 use zamsync_network::sign_node_cert;
 use zamsync_storage::EncryptionKey;
@@ -40,21 +41,43 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     let enc_key = EncryptionKey::generate()?;
     enc_key.to_file(tls_dir.join("data.key"))?;
 
-    println!("Clinic credentials signed in {}/tls/", clinic_dir.display());
+    println!(
+        "{} {}/tls/",
+        color::green("clinic credentials signed in"),
+        clinic_dir.display()
+    );
     println!();
-    println!("  ca.crt   -- hub CA certificate (same as hub's ca.crt)");
-    println!("  node.crt -- clinic node certificate, signed by hub CA");
-    println!("  node.key -- clinic node private key (never share)");
-    println!("  data.key -- WAL encryption key for this clinic node");
+    println!(
+        "  {}  hub CA certificate (same as hub's ca.crt)",
+        color::dim("ca.crt  --")
+    );
+    println!(
+        "  {}  clinic node certificate, signed by hub CA",
+        color::dim("node.crt--")
+    );
+    println!(
+        "  {}  clinic node private key (never share)",
+        color::dim("node.key--")
+    );
+    println!(
+        "  {}  WAL encryption key for this clinic node",
+        color::dim("data.key--")
+    );
     println!();
     println!("Deploy to the clinic device and run:");
     println!(
-        "  zamsync serve {0} <bind-addr> --tls --key-file {0}/tls/data.key",
-        clinic_dir.display()
+        "  {}",
+        color::dim(&format!(
+            "zamsync serve {0} <bind-addr> --tls --key-file {0}/tls/data.key",
+            clinic_dir.display()
+        ))
     );
     println!(
-        "  zamsync sync  {0} <hub-addr>  <hub-id> --tls --key-file {0}/tls/data.key",
-        clinic_dir.display()
+        "  {}",
+        color::dim(&format!(
+            "zamsync sync  {0} <hub-addr>  <hub-id> --tls --key-file {0}/tls/data.key",
+            clinic_dir.display()
+        ))
     );
     Ok(())
 }

--- a/src/cmd/submit.rs
+++ b/src/cmd/submit.rs
@@ -1,3 +1,4 @@
+use crate::color;
 use crate::util::{data_dir, load_encryption_key, load_schema, node_id_from_dir, open_engine};
 
 pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
@@ -9,6 +10,6 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     let mut engine = open_engine(&dir, node_id, enc_key, schema)?;
     let seq = engine.submit(1, payload)?;
     engine.sync()?;
-    println!("submitted seq={}", seq.0);
+    println!("{} seq={}", color::green("submitted"), seq.0);
     Ok(())
 }

--- a/src/cmd/sync.rs
+++ b/src/cmd/sync.rs
@@ -1,3 +1,4 @@
+use crate::color;
 use crate::metrics::start_metrics_server;
 use crate::util::{
     data_dir, flag_value, is_transient, load_encryption_key, load_schema, load_tls_config,
@@ -50,11 +51,17 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
         match sync_result {
             Ok(stats) => {
                 print!(
-                    "sync done: sent={} received={} bytes={}",
-                    stats.events_sent, stats.events_received, stats.bytes_sent
+                    "{}  sent={}  received={}  bytes={}",
+                    color::green("sync done:"),
+                    stats.events_sent,
+                    stats.events_received,
+                    stats.bytes_sent,
                 );
                 if stats.budget_exhausted {
-                    print!(" (budget exhausted -- resume with next sync)");
+                    print!(
+                        "  {}",
+                        color::yellow("budget exhausted -- resume with next sync")
+                    );
                 }
                 println!();
                 return Ok(());
@@ -62,8 +69,9 @@ pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
             Err(ref e) if is_transient(e) && attempt < MAX_ATTEMPTS => {
                 let delay_ms = 100u64 * (1 << (attempt - 1));
                 eprintln!(
-                    "sync attempt {}/{MAX_ATTEMPTS} failed ({}), retrying in {delay_ms}ms",
-                    attempt, e
+                    "{}  attempt {}/{MAX_ATTEMPTS} failed ({e}), retrying in {delay_ms}ms",
+                    color::yellow("sync warn:"),
+                    attempt,
                 );
                 std::thread::sleep(std::time::Duration::from_millis(delay_ms));
             }

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,0 +1,232 @@
+/// Terminal color support for ZamSync CLI output.
+///
+/// Colors are disabled automatically when:
+///   - stdout is not a TTY (piped or redirected)
+///   - the `NO_COLOR` environment variable is set (https://no-color.org)
+///   - the `TERM` environment variable is set to `dumb`
+///   - `--no-color` is present anywhere in the command arguments
+///
+/// Any of these conditions is sufficient to disable colors.
+use std::io::IsTerminal;
+use std::sync::OnceLock;
+
+const RED: &str = "\x1b[31m";
+const GREEN: &str = "\x1b[32m";
+const YELLOW: &str = "\x1b[33m";
+const BOLD: &str = "\x1b[1m";
+const DIM: &str = "\x1b[2m";
+const RESET: &str = "\x1b[0m";
+
+static ENABLED: OnceLock<bool> = OnceLock::new();
+
+/// Returns true if color output is enabled for this process.
+pub fn is_enabled() -> bool {
+    *ENABLED.get_or_init(|| {
+        std::io::stdout().is_terminal()
+            && std::env::var("NO_COLOR").is_err()
+            && std::env::var("TERM").map_or(true, |t| t != "dumb")
+            && !std::env::args().any(|a| a == "--no-color")
+    })
+}
+
+// ---- Core primitive --------------------------------------------------------
+
+/// Apply `code` around `s` when `enabled` is true. Used internally and in tests.
+pub(crate) fn paint(s: &str, code: &str, enabled: bool) -> String {
+    if enabled {
+        format!("{code}{s}{RESET}")
+    } else {
+        s.to_owned()
+    }
+}
+
+// ---- Public color functions ------------------------------------------------
+
+pub fn green(s: &str) -> String {
+    paint(s, GREEN, is_enabled())
+}
+
+pub fn red(s: &str) -> String {
+    paint(s, RED, is_enabled())
+}
+
+pub fn yellow(s: &str) -> String {
+    paint(s, YELLOW, is_enabled())
+}
+
+pub fn bold(s: &str) -> String {
+    paint(s, BOLD, is_enabled())
+}
+
+pub fn dim(s: &str) -> String {
+    paint(s, DIM, is_enabled())
+}
+
+// ---- Domain-specific helpers -----------------------------------------------
+
+/// Color an RTT value: green < 100 ms, yellow < 500 ms, red >= 500 ms.
+pub fn rtt(ms: u128) -> String {
+    rtt_paint(ms, is_enabled())
+}
+
+pub(crate) fn rtt_paint(ms: u128, enabled: bool) -> String {
+    let s = format!("{ms}ms");
+    let code = if ms < 100 {
+        GREEN
+    } else if ms < 500 {
+        YELLOW
+    } else {
+        RED
+    };
+    paint(&s, code, enabled)
+}
+
+/// Color a packet-loss percentage: green = 0 %, yellow <= 50 %, red > 50 %.
+pub fn loss(failures: usize, total: usize) -> String {
+    loss_paint(failures, total, is_enabled())
+}
+
+pub(crate) fn loss_paint(failures: usize, total: usize, enabled: bool) -> String {
+    let pct = if total == 0 {
+        0
+    } else {
+        (failures * 100) / total
+    };
+    let s = format!("loss={pct}%");
+    let code = if pct == 0 {
+        GREEN
+    } else if pct <= 50 {
+        YELLOW
+    } else {
+        RED
+    };
+    paint(&s, code, enabled)
+}
+
+// ---- Tests -----------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // All tests use the internal `paint` / `*_paint` helpers with an explicit
+    // `enabled` flag so they are deterministic regardless of TTY state or
+    // environment variables.
+
+    #[test]
+    fn paint_enabled_wraps_ansi() {
+        let out = paint("hello", GREEN, true);
+        assert!(
+            out.starts_with("\x1b[32m"),
+            "expected green escape, got {out:?}"
+        );
+        assert!(out.ends_with(RESET), "expected reset suffix");
+        assert!(out.contains("hello"), "original text must be present");
+    }
+
+    #[test]
+    fn paint_disabled_returns_plain() {
+        assert_eq!(paint("hello", GREEN, false), "hello");
+        assert_eq!(paint("hello", RED, false), "hello");
+        assert_eq!(paint("hello", BOLD, false), "hello");
+    }
+
+    #[test]
+    fn each_color_has_distinct_code() {
+        let g = paint("x", GREEN, true);
+        let r = paint("x", RED, true);
+        let y = paint("x", YELLOW, true);
+        let b = paint("x", BOLD, true);
+        let d = paint("x", DIM, true);
+        // All different from each other
+        let variants = [&g, &r, &y, &b, &d];
+        for (i, a) in variants.iter().enumerate() {
+            for (j, b) in variants.iter().enumerate() {
+                if i != j {
+                    assert_ne!(a, b, "color variant {i} and {j} should differ");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn rtt_below_100_is_green() {
+        let out = rtt_paint(0, true);
+        assert!(out.starts_with("\x1b[32m"), "0ms should be green");
+        let out = rtt_paint(99, true);
+        assert!(out.starts_with("\x1b[32m"), "99ms should be green");
+    }
+
+    #[test]
+    fn rtt_100_to_499_is_yellow() {
+        let out = rtt_paint(100, true);
+        assert!(out.starts_with("\x1b[33m"), "100ms should be yellow");
+        let out = rtt_paint(499, true);
+        assert!(out.starts_with("\x1b[33m"), "499ms should be yellow");
+    }
+
+    #[test]
+    fn rtt_500_and_above_is_red() {
+        let out = rtt_paint(500, true);
+        assert!(out.starts_with("\x1b[31m"), "500ms should be red");
+        let out = rtt_paint(1200, true);
+        assert!(out.starts_with("\x1b[31m"), "1200ms should be red");
+    }
+
+    #[test]
+    fn rtt_disabled_is_plain_text() {
+        assert_eq!(rtt_paint(42, false), "42ms");
+        assert_eq!(rtt_paint(250, false), "250ms");
+        assert_eq!(rtt_paint(600, false), "600ms");
+    }
+
+    #[test]
+    fn loss_zero_is_green() {
+        let out = loss_paint(0, 3, true);
+        assert!(
+            out.starts_with("\x1b[32m"),
+            "0% loss should be green: {out:?}"
+        );
+        assert!(out.contains("loss=0%"));
+    }
+
+    #[test]
+    fn loss_partial_is_yellow() {
+        let out = loss_paint(1, 3, true); // 33%
+        assert!(
+            out.starts_with("\x1b[33m"),
+            "33% loss should be yellow: {out:?}"
+        );
+        let out = loss_paint(1, 2, true); // 50%
+        assert!(
+            out.starts_with("\x1b[33m"),
+            "50% loss should be yellow: {out:?}"
+        );
+    }
+
+    #[test]
+    fn loss_majority_is_red() {
+        let out = loss_paint(2, 3, true); // 66%
+        assert!(
+            out.starts_with("\x1b[31m"),
+            "66% loss should be red: {out:?}"
+        );
+        let out = loss_paint(3, 3, true); // 100%
+        assert!(
+            out.starts_with("\x1b[31m"),
+            "100% loss should be red: {out:?}"
+        );
+    }
+
+    #[test]
+    fn loss_disabled_is_plain_text() {
+        assert_eq!(loss_paint(0, 3, false), "loss=0%");
+        assert_eq!(loss_paint(3, 3, false), "loss=100%");
+    }
+
+    #[test]
+    fn loss_zero_total_does_not_panic() {
+        let out = loss_paint(0, 0, false);
+        assert_eq!(out, "loss=0%");
+    }
+}

--- a/src/color.rs
+++ b/src/color.rs
@@ -87,11 +87,7 @@ pub fn loss(failures: usize, total: usize) -> String {
 }
 
 pub(crate) fn loss_paint(failures: usize, total: usize, enabled: bool) -> String {
-    let pct = if total == 0 {
-        0
-    } else {
-        (failures * 100) / total
-    };
+    let pct = (failures * 100).checked_div(total).unwrap_or(0);
     let s = format!("loss={pct}%");
     let code = if pct == 0 {
         GREEN

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod cmd;
+mod color;
 mod http;
 mod metrics;
 mod util;


### PR DESCRIPTION
## Summary

- New `src/color.rs` module with `green`/`red`/`yellow`/`bold`/`dim` helpers and RTT/loss threshold colorizers
- Color auto-detected via `std::io::IsTerminal`; disabled by `NO_COLOR` env var, `TERM=dumb`, or `--no-color` CLI flag (no-color.org standard)
- All CLI commands receive color treatment: `submit`, `ping`, `daemon`, `sync`, `info`, `audit`, `keygen`, `sign`, `serve`, `project`, `expire`
- `audit` command gains `--format csv` support (header row + comma-separated output)
- Usage string updated: `--format json|text|csv`, color disable docs added

## Color scheme

| Output | Color |
|--------|-------|
| Success / peer done / submitted | green |
| Warnings / retries / budget / loss | yellow |
| Errors / high RTT | red |
| Labels / timestamps / dim details | dim |
| Node IDs / event counts / headers | bold |
| RTT < 100ms | green |
| RTT 100-499ms | yellow |
| RTT >= 500ms | red |

## Disable color

```bash
zamsync ping ./data 127.0.0.1:5000 --no-color
NO_COLOR=1 zamsync serve ./data 0.0.0.0:5000
TERM=dumb zamsync audit ./data
```

## Test plan

- [ ] `cargo test --workspace` -- 141 tests pass
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` -- clean
- [ ] `cargo fmt --all` -- no changes
- [ ] Verify color output in a real terminal with `zamsync ping` and `zamsync serve`
- [ ] Verify `--no-color` suppresses all ANSI codes
- [ ] Verify `NO_COLOR=1` suppresses all ANSI codes
- [ ] Verify `zamsync audit --format csv` produces valid CSV